### PR TITLE
This makes the api in the config.yaml optional

### DIFF
--- a/test/config.yaml
+++ b/test/config.yaml
@@ -1,9 +1,8 @@
-api:
-  interval: 1s
-  uri: "https://app.compose.io/services/transporter/v1/events"
-  # uri: "http://requestb.in/13gerls1"
-  key: "48593282-b38d-4bf5-af58-f7327271e73d"
-  pid: "something-static"
+# api:
+#   interval: 60s
+#   uri: "http://requestb.in/13gerls1"
+#   key: "48593282-b38d-4bf5-af58-f7327271e73d"
+#   pid: "something-static"
 nodes:
   localmongo:
     type: mongo


### PR DESCRIPTION
default to a 60s interval if no interval is passed in.  
if no config.API.URI is passed in then use an events.NoopEmitter instead of an HttpPostEmitter when building the pipeline.
the default interval is needed, because we need an interval on the pipeline constructor, whether or not we use it  
fixes #13 
fixes #14
