### PR TITLE
add a quick benchmark to transformOne

### DIFF
--- a/pkg/adaptor/transformer_test.go
+++ b/pkg/adaptor/transformer_test.go
@@ -93,3 +93,23 @@ func TestTransformOne(t *testing.T) {
 		}
 	}
 }
+
+func BenchmarkTransformOne(b *testing.B) {
+	tpipe := pipe.NewPipe(nil, "path")
+	transformer := &Transformer{
+		pipe: tpipe,
+		path: "path",
+		fn:   "module.exports=function(doc) { return doc }",
+	}
+	err := transformer.initEnvironment()
+	if err != nil {
+		panic(err)
+	}
+
+	msg := message.NewMsg(message.Insert, map[string]interface{}{"id": bson.NewObjectId(), "name": "nick"})
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		transformer.transformOne(msg)
+	}
+}


### PR DESCRIPTION
nothing much to see here

```
$ go test ./... -bench .
?       github.com/compose/transporter/cmd/transporter  [no test files]
PASS
BenchmarkTransformOne     100000         18766 ns/op
ok      github.com/compose/transporter/pkg/adaptor  2.208s
PASS
ok      github.com/compose/transporter/pkg/events   0.007s
PASS
ok      github.com/compose/transporter/pkg/message  0.004s
?       github.com/compose/transporter/pkg/pipe [no test files]
PASS
ok      github.com/compose/transporter/pkg/transporter  0.008s
```
