### PR TITLE
41 config

### DIFF
--- a/pkg/adaptor/adaptor.go
+++ b/pkg/adaptor/adaptor.go
@@ -2,7 +2,7 @@ package adaptor
 
 import (
 	"encoding/json"
-	"errors"
+	// "errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -10,10 +10,14 @@ import (
 	"github.com/compose/transporter/pkg/pipe"
 )
 
-var (
-	// ErrMissingNode is returned when the requested node type was not found in the map
-	ErrMissingNode = errors.New("adaptor not found in registry")
-)
+// ErrAdaptor gives the details of the failed adaptor
+type ErrAdaptor struct {
+	name string
+}
+
+func (a ErrAdaptor) Error() string {
+	return fmt.Sprintf("adaptor '%s' not found in registry", a.name)
+}
 
 // StopStartListener defines the interface that all database connectors and nodes must follow.
 // Start() consumes data from the interface,
@@ -38,7 +42,7 @@ func Createadaptor(kind, path string, extra Config, p *pipe.Pipe) (adaptor StopS
 
 	regentry, ok := Adaptors[kind]
 	if !ok {
-		return nil, ErrMissingNode
+		return nil, ErrAdaptor{kind}
 	}
 
 	args := []reflect.Value{

--- a/pkg/adaptor/adaptor_test.go
+++ b/pkg/adaptor/adaptor_test.go
@@ -58,14 +58,14 @@ func TestCreateadaptor(t *testing.T) {
 			"notasource",
 			Config{"blah": "rockettes"},
 			nil,
-			"adaptor not found in registry",
+			"adaptor 'notasource' not found in registry",
 		},
 	}
 	for _, v := range data {
 		adaptor, err := Createadaptor(v.kind, "a/b/c", v.extra, pipe.NewPipe(nil, "some name"))
 
 		if err != nil && err.Error() != v.err {
-			t.Errorf("\nexpected error: %v\ngot error: %v\n", v.err, err.Error())
+			t.Errorf("\nexpected error: `%v`\ngot error: `%v`\n", v.err, err.Error())
 			t.FailNow()
 		}
 		if !reflect.DeepEqual(v.out, adaptor) && err == nil {

--- a/pkg/adaptor/elasticsearch.go
+++ b/pkg/adaptor/elasticsearch.go
@@ -34,7 +34,7 @@ func NewElasticsearch(p *pipe.Pipe, path string, extra Config) (StopStartListene
 		err  error
 	)
 	if err = extra.Construct(&conf); err != nil {
-		return nil, NewError(CRITICAL, path, fmt.Sprintf("Can't create constructor (%s)", err.Error()), nil)
+		return nil, NewError(CRITICAL, path, fmt.Sprintf("can't create constructor (%s)", err.Error()), nil)
 	}
 
 	u, err := url.Parse(conf.URI)
@@ -49,7 +49,7 @@ func NewElasticsearch(p *pipe.Pipe, path string, extra Config) (StopStartListene
 
 	e.index, e._type, err = extra.splitNamespace()
 	if err != nil {
-		return e, NewError(CRITICAL, path, fmt.Sprintf("Can't split namespace into _index._type (%s)", err.Error()), nil)
+		return e, NewError(CRITICAL, path, fmt.Sprintf("can't split namespace into _index._type (%s)", err.Error()), nil)
 	}
 
 	return e, nil
@@ -57,7 +57,7 @@ func NewElasticsearch(p *pipe.Pipe, path string, extra Config) (StopStartListene
 
 // Start the adaptor as a source (not implemented)
 func (e *Elasticsearch) Start() error {
-	return fmt.Errorf("Elasticsearch can't function as a source")
+	return fmt.Errorf("elasticsearch can't function as a source")
 }
 
 // Listen starts the listener
@@ -68,7 +68,7 @@ func (e *Elasticsearch) Listen() error {
 
 	go func(cherr chan *elastigo.ErrorBuffer) {
 		for err := range e.indexer.ErrorChannel {
-			e.pipe.Err <- NewError(CRITICAL, e.path, fmt.Sprintf("Elasticsearch error (%s)", err.Err), nil)
+			e.pipe.Err <- NewError(CRITICAL, e.path, fmt.Sprintf("elasticsearch error (%s)", err.Err), nil)
 		}
 	}(e.indexer.ErrorChannel)
 
@@ -97,7 +97,7 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 	if msg.Op == message.Command {
 		err := e.runCommand(msg)
 		if err != nil {
-			e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("Elasticsearch error (%s)", err), msg.Data)
+			e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
 		}
 		return msg, nil
 	}
@@ -109,7 +109,7 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 	}
 	err = e.indexer.Index(e.index, e._type, id, "", nil, msg.Data, false)
 	if err != nil {
-		e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("Elasticsearch error (%s)", err), msg.Data)
+		e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
 	}
 	return msg, nil
 }

--- a/pkg/adaptor/influxdb.go
+++ b/pkg/adaptor/influxdb.go
@@ -58,7 +58,7 @@ func NewInfluxdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, er
 
 // Start the adaptor as a source (not implemented)
 func (i *Influxdb) Start() error {
-	return fmt.Errorf("Influxdb can't function as a source")
+	return fmt.Errorf("influxdb can't function as a source")
 }
 
 // Listen starts the listener
@@ -82,7 +82,7 @@ func (i *Influxdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 	switch msg.Op {
 	case message.Insert:
 		if !msg.IsMap() {
-			i.pipe.Err <- NewError(ERROR, i.path, "Influxdb error (document must be a json document)", msg.Data)
+			i.pipe.Err <- NewError(ERROR, i.path, "influxdb error (document must be a json document)", msg.Data)
 			return msg, nil
 		}
 		doc := msg.Map()

--- a/pkg/adaptor/mongodb.go
+++ b/pkg/adaptor/mongodb.go
@@ -122,7 +122,7 @@ func (m *Mongodb) writeMessage(msg *message.Msg) (*message.Msg, error) {
 	collection := m.mongoSession.DB(m.database).C(m.collection)
 
 	if !msg.IsMap() {
-		m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("Mongodb error (document must be a bson document, got %T instead)", msg.Data), msg.Data)
+		m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (document must be a bson document, got %T instead)", msg.Data), msg.Data)
 		return msg, nil
 	}
 
@@ -133,7 +133,7 @@ func (m *Mongodb) writeMessage(msg *message.Msg) (*message.Msg, error) {
 		err = collection.Update(bson.M{"_id": doc["_id"]}, doc)
 	}
 	if err != nil {
-		m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("Mongodb error (%s)", err.Error()), msg.Data)
+		m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), msg.Data)
 	}
 	return msg, nil
 }
@@ -253,7 +253,7 @@ func (m *Mongodb) tailData() (err error) {
 func (m *Mongodb) getOriginalDoc(doc bson.M) (result bson.M, err error) {
 	id, exists := doc["_id"]
 	if !exists {
-		return result, fmt.Errorf("Can't get _id from document")
+		return result, fmt.Errorf("can't get _id from document")
 	}
 
 	err = m.mongoSession.DB(m.database).C(m.collection).FindId(id).One(&result)

--- a/pkg/adaptor/mongodb.go
+++ b/pkg/adaptor/mongodb.go
@@ -81,7 +81,7 @@ func (m *Mongodb) Start() (err error) {
 
 	m.oplogTime = nowAsMongoTimestamp()
 	if m.debug {
-		fmt.Printf("setting start timestamp: %d", m.oplogTime)
+		fmt.Printf("setting start timestamp: %d\n", m.oplogTime)
 	}
 
 	err = m.catData()

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -63,7 +63,7 @@ func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, e
 
 // Start the adaptor as a source (not implemented)
 func (r *Rethinkdb) Start() error {
-	return fmt.Errorf("Rethinkdb can't function as a source")
+	return fmt.Errorf("rethinkdb can't function as a source")
 }
 
 // Listen start's the adaptor's listener
@@ -91,7 +91,7 @@ func (r *Rethinkdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 	)
 
 	if !msg.IsMap() {
-		r.pipe.Err <- NewError(ERROR, r.path, "Rethinkdb error (document must be a json document)", msg.Data)
+		r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (document must be a json document)", msg.Data)
 		return msg, nil
 	}
 	doc := msg.Map()
@@ -100,7 +100,7 @@ func (r *Rethinkdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 	case message.Delete:
 		id, err := msg.IDString("id")
 		if err != nil {
-			r.pipe.Err <- NewError(ERROR, r.path, "Rethinkdb error (cannot delete an object with a nil id)", msg.Data)
+			r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (cannot delete an object with a nil id)", msg.Data)
 			return msg, nil
 		}
 		resp, err = gorethink.Table(r.table).Get(id).Delete().RunWrite(r.client)
@@ -110,13 +110,13 @@ func (r *Rethinkdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 		resp, err = gorethink.Table(r.table).Insert(doc, gorethink.InsertOpts{Conflict: "replace"}).RunWrite(r.client)
 	}
 	if err != nil {
-		r.pipe.Err <- NewError(ERROR, r.path, "Rethinkdb error (%s)", err)
+		r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (%s)", err)
 		return msg, nil
 	}
 
 	err = r.handleResponse(&resp)
 	if err != nil {
-		r.pipe.Err <- NewError(ERROR, r.path, "Rethinkdb error (%s)", err)
+		r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (%s)", err)
 	}
 
 	return msg, nil
@@ -133,7 +133,7 @@ func (r *Rethinkdb) setupClient() (*gorethink.Session, error) {
 		IdleTimeout: time.Second * 10,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Unable to connect: %s", err)
+		return nil, fmt.Errorf("unable to connect: %s", err)
 	}
 
 	if r.debug {
@@ -153,7 +153,7 @@ func (r *Rethinkdb) handleResponse(resp *gorethink.WriteResponse) error {
 			if r.debug {
 				fmt.Printf("Reported %d errors\n", resp.Errors)
 			}
-			return fmt.Errorf("%s\n%s", "Problem inserting docs", resp.FirstError)
+			return fmt.Errorf("%s\n%s", "problem inserting docs", resp.FirstError)
 		}
 	}
 	return nil

--- a/pkg/adaptor/transformer.go
+++ b/pkg/adaptor/transformer.go
@@ -39,7 +39,7 @@ func NewTransformer(pipe *pipe.Pipe, path string, extra Config) (StopStartListen
 	t := &Transformer{pipe: pipe, path: path}
 
 	if conf.Filename == "" {
-		return t, fmt.Errorf("No filename specified")
+		return t, fmt.Errorf("no filename specified")
 	}
 
 	ba, err := ioutil.ReadFile(conf.Filename)
@@ -87,7 +87,7 @@ func (t *Transformer) initEnvironment() (err error) {
 
 // Start the adaptor as a source (not implemented for this adaptor)
 func (t *Transformer) Start() error {
-	return fmt.Errorf("Transformers can't be used as a source")
+	return fmt.Errorf("transformers can't be used as a source")
 }
 
 // Stop the adaptor
@@ -168,9 +168,9 @@ func (t *Transformer) transformerError(lvl ErrorLevel, err error, msg *message.M
 	}
 
 	if e, ok := err.(*otto.Error); ok {
-		return NewError(lvl, t.path, fmt.Sprintf("Transformer error (%s)", e.String()), data)
+		return NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", e.String()), data)
 	}
-	return NewError(lvl, t.path, fmt.Sprintf("Transformer error (%s)", err.Error()), data)
+	return NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", err.Error()), data)
 }
 
 // TransformerConfig holds config options for a transformer adaptor

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -61,11 +61,11 @@ func (m *Msg) Map() map[string]interface{} {
 func (m *Msg) IDString(key string) (string, error) {
 	doc, ok := m.Data.(map[string]interface{})
 	if !ok {
-		return "", fmt.Errorf("Data is not a map")
+		return "", fmt.Errorf("data is not a map")
 	}
 	id, ok := doc[key]
 	if !ok {
-		return "", fmt.Errorf("No key %s found in Data", key)
+		return "", fmt.Errorf("no key %s found in Data", key)
 	}
 	switch t := id.(type) {
 	case string:

--- a/pkg/message/message_test.go
+++ b/pkg/message/message_test.go
@@ -49,7 +49,7 @@ func TestIdString(t *testing.T) {
 		msg := NewMsg(OpTypeFromString("insert"), v.in)
 		id, err := msg.IDString(v.key)
 		if (err != nil) != v.err {
-			t.Error("expected error: %t, but got error: %v", v.err, err)
+			t.Errorf("expected error: %t, but got error: %v", v.err, err)
 		}
 		if id != v.want {
 			t.Errorf("IdString failed.  expected %+v, got %+v", v.want, id)


### PR DESCRIPTION
when pulling information about a node from the config file, the options were being overwritten.  so when the same config was used twice in a pipeline, the second options were overwriting the first.  
explicitly copy the map to avoid that problem.
as well, some minor lint fixes and a new ErrAdaptor that lets us have more information about what the problem is with the adaptor

fixes #41 
