### PR TITLE
Adapter: Implements RethinkDB as a source of documents

### DIFF
--- a/pkg/adaptor/elasticsearch.go
+++ b/pkg/adaptor/elasticsearch.go
@@ -101,13 +101,21 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 		}
 		return msg, nil
 	}
+
 	// TODO there might be some inconsistency here.  elasticsearch uses the _id field for an primary index,
 	//  and we're just mapping it to a string here.
 	id, err := msg.IDString("_id")
 	if err != nil {
 		id = ""
 	}
-	err = e.indexer.Index(e.index, e._type, id, "", nil, msg.Data, false)
+
+	switch msg.Op {
+	case message.Delete:
+		e.indexer.Delete(e.index, e._type, id, false)
+		err = nil
+	default:
+		err = e.indexer.Index(e.index, e._type, id, "", nil, msg.Data, false)
+	}
 	if err != nil {
 		e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
 	}

--- a/pkg/adaptor/registry.go
+++ b/pkg/adaptor/registry.go
@@ -18,7 +18,7 @@ func init() {
 	Register("elasticsearch", "an elasticsearch sink adaptor", NewElasticsearch, dbConfig{})
 	// Register("influx", "an InfluxDB sink adaptor", NewInfluxdb, dbConfig{})
 	Register("transformer", "an adaptor that transforms documents using a javascript function", NewTransformer, TransformerConfig{})
-	Register("rethinkdb", "a rethinkdb sink adaptor", NewRethinkdb, dbConfig{})
+	Register("rethinkdb", "a rethinkdb sink adaptor", NewRethinkdb, rethinkDbConfig{})
 }
 
 // Register registers an adaptor (database adaptor) for use with Transporter

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -101,6 +101,7 @@ func (r *Rethinkdb) Start() error {
 		r.pipe.Err <- err
 		return err
 	}
+	defer ccursor.Close()
 
 	if err := r.sendAllDocuments(); err != nil {
 		r.pipe.Err <- err
@@ -127,6 +128,7 @@ func (r *Rethinkdb) sendAllDocuments() error {
 	if err != nil {
 		return err
 	}
+	defer cursor.Close()
 
 	var doc map[string]interface{}
 	for cursor.Next(&doc) {

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -85,7 +85,7 @@ func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, e
 		Timeout: time.Second * 10,
 	})
 	if err != nil {
-		return nil, err
+		return r, err
 	}
 	r.client.Use(r.database)
 

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -33,8 +33,8 @@ type Rethinkdb struct {
 	client *gorethink.Session
 }
 
-// RethinkdbConfig provides custom configuration options for the RethinkDB adapter
-type RethinkdbConfig struct {
+// rethinkDbConfig provides custom configuration options for the RethinkDB adapter
+type rethinkDbConfig struct {
 	URI       string `json:"uri" doc:"the uri to connect to, in the form rethink://user:password@host.example:28015/database"`
 	Namespace string `json:"namespace" doc:"rethink namespace to read/write, in the form database.table"`
 	Debug     bool   `json:"debug" doc:"if true, verbose debugging information is displayed"`
@@ -50,7 +50,7 @@ type rethinkDbChangeNotification struct {
 // NewRethinkdb creates a new Rethinkdb database adaptor
 func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
 	var (
-		conf RethinkdbConfig
+		conf rethinkDbConfig
 		err  error
 	)
 	if err = extra.Construct(&conf); err != nil {
@@ -63,7 +63,7 @@ func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, e
 	}
 
 	if conf.Debug {
-		fmt.Printf("RethinkdbConfig: %#v\n", conf)
+		fmt.Printf("rethinkDbConfig: %#v\n", conf)
 	}
 
 	r := &Rethinkdb{

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -84,7 +84,7 @@ func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, e
 	return r, nil
 }
 
-// Start the adaptor as a source (not implemented)
+// Start the adaptor as a source
 func (r *Rethinkdb) Start() error {
 	if r.debug {
 		fmt.Printf("getting a changes cursor\n")

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -113,7 +113,6 @@ func (r *Rethinkdb) Start() error {
 		return err
 	}
 
-	// Monitor for changes
 	if r.tail {
 		if err := r.sendChanges(ccursor); err != nil {
 			r.pipe.Err <- err

--- a/test/application-rethink-to-es.js
+++ b/test/application-rethink-to-es.js
@@ -1,0 +1,3 @@
+Source({"name": "rethink1", "namespace": "test.transporter", "tail": true, "debug": true}).
+  transform({"filename": "transformers/rethink_id_to_elasticsearch_id.js"}).
+  save({"name": "locales", "namespace": "test.transporter"})

--- a/test/application-rethink-to-es.js
+++ b/test/application-rethink-to-es.js
@@ -1,3 +1,2 @@
 Source({"name": "rethink1", "namespace": "test.transporter", "tail": true, "debug": true}).
-  transform({"filename": "transformers/rethink_id_to_elasticsearch_id.js"}).
   save({"name": "locales", "namespace": "test.transporter"})

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -12,6 +12,9 @@ nodes:
   es:
     type: elasticsearch
     uri: https://nick:darling@haproxy1.dblayer.com:10291/thisgetsignored
+  locales:
+    type: elasticsearch
+    uri: http://localhost:9200/thisgetsignored
   timeseries:
     type: influx
     uri: influxdb://root:root@localhost:8086/compose
@@ -32,7 +35,7 @@ nodes:
     uri: stdout://
   rethink1:
     type: rethinkdb
-    uri: rethink://127.0.0.2:28015/
+    uri: rethink://localhost:28015/
   loosefile:
     type: file
   logtransformer:

--- a/test/transformers/rethink_id_to_elasticsearch_id.js
+++ b/test/transformers/rethink_id_to_elasticsearch_id.js
@@ -1,0 +1,6 @@
+module.exports = function(doc) {
+  doc["_id"] = doc["id"];
+  delete doc["id"];
+
+  return doc;
+}

--- a/test/transformers/rethink_id_to_elasticsearch_id.js
+++ b/test/transformers/rethink_id_to_elasticsearch_id.js
@@ -1,6 +1,0 @@
-module.exports = function(doc) {
-  doc["_id"] = doc["id"];
-  delete doc["id"];
-
-  return doc;
-}


### PR DESCRIPTION
Similar to the MongoDB adapter, this proposed RethinkDB source sends all documents in the table, then (if configured via the `tail` configuration parameter) watches for changes via RethinkDB's Changefeeds feature.

Also implemented is a small change to the ElasticSearch adapter to support `Delete` operations.

:eyes: in the form of code review definitely welcomed.

/cc: @brandon-beacher