### PR TITLE
throw transformer initialization errors early

### DIFF
--- a/pkg/adaptor/transformer.go
+++ b/pkg/adaptor/transformer.go
@@ -49,6 +49,10 @@ func NewTransformer(pipe *pipe.Pipe, path string, extra Config) (StopStartListen
 
 	t.fn = string(ba)
 
+	if err = t.initEnvironment(); err != nil {
+		return t, err
+	}
+
 	return t, nil
 }
 
@@ -56,10 +60,6 @@ func NewTransformer(pipe *pipe.Pipe, path string, extra Config) (StopStartListen
 // transformers it into mejson, and then uses the supplied javascript module.exports function
 // to transform the document.  The document is then emited to this adaptor's children
 func (t *Transformer) Listen() (err error) {
-	if err = t.initEnvironment(); err != nil {
-		return err
-	}
-
 	return t.pipe.Listen(t.transformOne)
 }
 


### PR DESCRIPTION
move the transformer initialization into the constructor rather then the Listen method

fixes #96 
