### PR TITLE
(Phase 1) Multi namespace support

### DIFF
--- a/cmd/transporter/config.go
+++ b/cmd/transporter/config.go
@@ -1,12 +1,13 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"time"
-
-	"gopkg.in/yaml.v2"
 )
 
 // A Config stores meta information about the transporter.  This contains a
@@ -39,6 +40,9 @@ func LoadConfig(filename string) (config Config, err error) {
 		return
 	}
 
+	// configs can have environment variables, replace these before continuing
+	ba = setConfigEnvironment(ba)
+
 	err = yaml.Unmarshal(ba, &config)
 
 	for k, v := range config.Nodes {
@@ -55,4 +59,22 @@ func LoadConfig(filename string) (config Config, err error) {
 	}
 
 	return
+}
+
+// setConfigEnvironment replaces environment variables marked in the form ${FOO} with the
+// value stored in the environment variable `FOO`
+func setConfigEnvironment(ba []byte) []byte {
+	re := regexp.MustCompile(`\$\{([a-zA-Z0-9]+)\}`)
+
+	matches := re.FindAllSubmatch(ba, -1)
+	if matches == nil {
+		return ba
+	}
+
+	for _, m := range matches {
+		v := os.Getenv(string(m[1]))
+		ba = bytes.Replace(ba, m[0], []byte(v), -1)
+	}
+
+	return ba
 }

--- a/pkg/adaptor/adaptor.go
+++ b/pkg/adaptor/adaptor.go
@@ -2,9 +2,9 @@ package adaptor
 
 import (
 	"encoding/json"
-	// "errors"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/compose/transporter/pkg/pipe"
@@ -106,6 +106,18 @@ func (c *Config) splitNamespace() (string, string, error) {
 		return "", "", fmt.Errorf("malformed namespace, expected a '.' deliminated string")
 	}
 	return fields[0], fields[1], nil
+}
+
+// compileNamespace split's on the first '.' and then compiles the second portion to use as the msg filter
+func (c *Config) compileNamespace() (string, *regexp.Regexp, error) {
+	field0, field1, err := c.splitNamespace()
+
+	if err != nil {
+		return "", nil, err
+	}
+
+	compiledNs, err := regexp.Compile(strings.Trim(field1, "/"))
+	return field0, compiledNs, err
 }
 
 // dbConfig is a standard typed config struct to use for as general purpose config for most databases.

--- a/pkg/adaptor/elasticsearch.go
+++ b/pkg/adaptor/elasticsearch.go
@@ -81,7 +81,7 @@ func (e *Elasticsearch) Listen() error {
 		}
 	}()
 
-	return e.pipe.Listen(e.typeMatch, e.applyOp)
+	return e.pipe.Listen(e.applyOp, e.typeMatch)
 }
 
 // Stop the adaptor

--- a/pkg/adaptor/file.go
+++ b/pkg/adaptor/file.go
@@ -16,7 +16,6 @@ import (
 // source / sink for file's on disk, as well as a sink to stdout.
 type File struct {
 	uri        string
-	namespace  string
 	pipe       *pipe.Pipe
 	path       string
 	filehandle *os.File
@@ -64,7 +63,7 @@ func (d *File) Listen() (err error) {
 		}
 	}
 
-	return d.pipe.Listen(regexp.MustCompile(`.*/`), d.dumpMessage)
+	return d.pipe.Listen(regexp.MustCompile(`.*`), d.dumpMessage)
 }
 
 // Stop the adaptor
@@ -91,7 +90,7 @@ func (d *File) readFile() (err error) {
 			d.pipe.Err <- NewError(ERROR, d.path, fmt.Sprintf("Can't marshal document (%s)", err.Error()), nil)
 			return err
 		}
-		d.pipe.Send(message.NewMsg(message.Insert, doc, ""))
+		d.pipe.Send(message.NewMsg(message.Insert, doc, fmt.Sprint("file.%s", filename)))
 	}
 	return nil
 }

--- a/pkg/adaptor/file.go
+++ b/pkg/adaptor/file.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/compose/transporter/pkg/message"
@@ -15,6 +16,7 @@ import (
 // source / sink for file's on disk, as well as a sink to stdout.
 type File struct {
 	uri        string
+	namespace  string
 	pipe       *pipe.Pipe
 	path       string
 	filehandle *os.File
@@ -62,7 +64,7 @@ func (d *File) Listen() (err error) {
 		}
 	}
 
-	return d.pipe.Listen(d.dumpMessage)
+	return d.pipe.Listen(regexp.MustCompile(`.*/`), d.dumpMessage)
 }
 
 // Stop the adaptor
@@ -89,7 +91,7 @@ func (d *File) readFile() (err error) {
 			d.pipe.Err <- NewError(ERROR, d.path, fmt.Sprintf("Can't marshal document (%s)", err.Error()), nil)
 			return err
 		}
-		d.pipe.Send(message.NewMsg(message.Insert, doc))
+		d.pipe.Send(message.NewMsg(message.Insert, doc, ""))
 	}
 	return nil
 }

--- a/pkg/adaptor/file.go
+++ b/pkg/adaptor/file.go
@@ -63,7 +63,7 @@ func (d *File) Listen() (err error) {
 		}
 	}
 
-	return d.pipe.Listen(regexp.MustCompile(`.*`), d.dumpMessage)
+	return d.pipe.Listen(d.dumpMessage, regexp.MustCompile(`.*`))
 }
 
 // Stop the adaptor

--- a/pkg/adaptor/mongodb.go
+++ b/pkg/adaptor/mongodb.go
@@ -183,7 +183,7 @@ func (m *Mongodb) Listen() (err error) {
 	if m.bulk {
 		go m.bulkWriter()
 	}
-	return m.pipe.Listen(m.collectionMatch, m.writeMessage)
+	return m.pipe.Listen(m.writeMessage, m.collectionMatch)
 }
 
 // Stop the adaptor

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/compose/transporter/pkg/message"
@@ -21,8 +22,8 @@ type Rethinkdb struct {
 	uri *url.URL
 
 	// save time by setting these once
-	database string
-	table    string
+	database   string
+	tableMatch *regexp.Regexp
 
 	debug bool
 	tail  bool
@@ -38,10 +39,9 @@ type Rethinkdb struct {
 // rethinkDbConfig provides custom configuration options for the RethinkDB adapter
 type rethinkDbConfig struct {
 	URI       string `json:"uri" doc:"the uri to connect to, in the form rethink://user:password@host.example:28015/database"`
-	Namespace string `json:"namespace" doc:"rethink namespace to read/write, in the form database.table"`
+	Namespace string `json:"namespace" doc:"rethink namespace to read/write"`
 	Debug     bool   `json:"debug" doc:"if true, verbose debugging information is displayed"`
 	Tail      bool   `json:"tail" doc:"if true, the RethinkDB table will be monitored for changes after copying the namespace"`
-	Timeout   int    `json:"timeout" doc:"timeout, in seconds, for connect, read, and write operations to the RethinkDB server; default is 10"`
 }
 
 type rethinkDbChangeNotification struct {
@@ -78,7 +78,7 @@ func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, e
 	}
 
 	if conf.Debug {
-		fmt.Printf("rethinkDbConfig: %#v\n", conf)
+		fmt.Printf("RethinkDB Config %+v\n", conf)
 	}
 
 	r := &Rethinkdb{
@@ -88,22 +88,30 @@ func NewRethinkdb(p *pipe.Pipe, path string, extra Config) (StopStartListener, e
 		tail: conf.Tail,
 	}
 
-	r.database, r.table, err = extra.splitNamespace()
+	r.database, r.tableMatch, err = extra.compileNamespace()
 	if err != nil {
 		return r, err
 	}
 	r.debug = conf.Debug
+	if r.debug {
+		fmt.Printf("tableMatch: %+v\n", r.tableMatch)
+	}
 
-	opts := gorethink.ConnectOpts{
+	// test the connection with a timeout
+	testConn, err := gorethink.Connect(gorethink.ConnectOpts{
+		Address: r.uri.Host,
+		Timeout: time.Second * 10,
+	})
+	if err != nil {
+		return r, err
+	}
+	testConn.Close()
+
+	// we don't want a timeout here because we want to keep connections open
+	r.client, err = gorethink.Connect(gorethink.ConnectOpts{
 		Address: r.uri.Host,
 		MaxIdle: 10,
-		Timeout: time.Second * 10,
-	}
-	if conf.Timeout > 0 {
-		opts.Timeout = time.Duration(conf.Timeout) * time.Second
-	}
-
-	r.client, err = gorethink.Connect(opts)
+	})
 	if err != nil {
 		return r, err
 	}
@@ -162,41 +170,73 @@ func (r *Rethinkdb) assertServerVersion(constraint version.Constraints) error {
 
 // Start the adaptor as a source
 func (r *Rethinkdb) Start() error {
-	if r.debug {
-		fmt.Printf("getting a changes cursor\n")
-	}
-
-	// Grab a changes cursor before sending all rows. The server will buffer
-	// changes while we reindex the entire table.
-	var ccursor *gorethink.Cursor
-	ccursor, err := gorethink.Table(r.table).Changes().Run(r.client)
+	tables, err := gorethink.DB(r.database).TableList().Run(r.client)
 	if err != nil {
-		r.pipe.Err <- err
 		return err
 	}
-	defer ccursor.Close()
+	defer tables.Close()
 
-	if err := r.sendAllDocuments(); err != nil {
-		r.pipe.Err <- err
-		return err
-	}
-
-	if r.tail {
-		if err := r.sendChanges(ccursor); err != nil {
-			r.pipe.Err <- err
-			return err
+	var (
+		wg     sync.WaitGroup
+		outerr error
+		table  string
+	)
+	for tables.Next(&table) {
+		if match := r.tableMatch.MatchString(table); !match {
+			if r.debug {
+				fmt.Printf("table, %s, didn't match\n", table)
+			}
+			continue
 		}
+		wg.Add(1)
+		start := make(chan bool)
+		if r.tail {
+			go r.startupChangesForTable(table, start, &wg)
+		}
+		go func(table string) {
+			defer wg.Done()
+
+			if err := r.sendAllDocuments(table); err != nil {
+				r.pipe.Err <- err
+				outerr = err
+			} else if r.tail {
+				start <- true
+			}
+			close(start)
+
+		}(table)
 	}
+	wg.Wait()
 
 	return nil
 }
 
-func (r *Rethinkdb) sendAllDocuments() error {
+func (r *Rethinkdb) startupChangesForTable(table string, start <-chan bool, wg *sync.WaitGroup) error {
+	wg.Add(1)
+	defer wg.Done()
 	if r.debug {
-		fmt.Printf("sending all documents\n")
+		fmt.Printf("getting a changes cursor for %s\n", table)
+	}
+	ccursor, err := gorethink.Table(table).Changes().Run(r.client)
+	if err != nil {
+		r.pipe.Err <- err
+		return err
+	}
+	// wait until time to start sending changes
+	<-start
+	if err := r.sendChanges(table, ccursor); err != nil {
+		r.pipe.Err <- err
+		return err
+	}
+	return nil
+}
+
+func (r *Rethinkdb) sendAllDocuments(table string) error {
+	if r.debug {
+		fmt.Printf("sending all documents for %s\n", table)
 	}
 
-	cursor, err := gorethink.Table(r.table).Run(r.client)
+	cursor, err := gorethink.Table(table).Run(r.client)
 	if err != nil {
 		return err
 	}
@@ -208,7 +248,7 @@ func (r *Rethinkdb) sendAllDocuments() error {
 			return nil
 		}
 
-		msg := message.NewMsg(message.Insert, r.prepareDocument(doc))
+		msg := message.NewMsg(message.Insert, r.prepareDocument(doc), r.computeNamespace(table))
 		r.pipe.Send(msg)
 	}
 
@@ -219,11 +259,11 @@ func (r *Rethinkdb) sendAllDocuments() error {
 	return nil
 }
 
-func (r *Rethinkdb) sendChanges(ccursor *gorethink.Cursor) error {
+func (r *Rethinkdb) sendChanges(table string, ccursor *gorethink.Cursor) error {
+	defer ccursor.Close()
 	if r.debug {
-		fmt.Printf("sending changes\n")
+		fmt.Printf("sending changes for %s\n", table)
 	}
-
 	var change rethinkDbChangeNotification
 	for ccursor.Next(&change) {
 		if stop := r.pipe.Stopped; stop {
@@ -238,16 +278,18 @@ func (r *Rethinkdb) sendChanges(ccursor *gorethink.Cursor) error {
 		if change.Error != "" {
 			return errors.New(change.Error)
 		} else if change.OldVal != nil && change.NewVal != nil {
-			msg = message.NewMsg(message.Update, r.prepareDocument(change.NewVal))
+			msg = message.NewMsg(message.Update, r.prepareDocument(change.NewVal), r.computeNamespace(table))
 		} else if change.NewVal != nil {
-			msg = message.NewMsg(message.Insert, r.prepareDocument(change.NewVal))
+			msg = message.NewMsg(message.Insert, r.prepareDocument(change.NewVal), r.computeNamespace(table))
 		} else if change.OldVal != nil {
-			msg = message.NewMsg(message.Delete, r.prepareDocument(change.OldVal))
+			msg = message.NewMsg(message.Delete, r.prepareDocument(change.OldVal), r.computeNamespace(table))
 		}
 
 		if msg != nil {
-			fmt.Printf("msg: %#v\n", msg)
 			r.pipe.Send(msg)
+			if r.debug {
+				fmt.Printf("msg: %#v\n", msg)
+			}
 		}
 	}
 
@@ -256,6 +298,10 @@ func (r *Rethinkdb) sendChanges(ccursor *gorethink.Cursor) error {
 	}
 
 	return nil
+}
+
+func (r *Rethinkdb) computeNamespace(table string) string {
+	return strings.Join([]string{r.database, table}, ".")
 }
 
 // prepareDocument moves the `id` field to the `_id` field, which is more
@@ -271,8 +317,7 @@ func (r *Rethinkdb) prepareDocument(doc map[string]interface{}) map[string]inter
 
 // Listen start's the adaptor's listener
 func (r *Rethinkdb) Listen() (err error) {
-	r.recreateTable()
-	return r.pipe.Listen(r.applyOp)
+	return r.pipe.Listen(r.tableMatch, r.applyOp)
 }
 
 // Stop the adaptor
@@ -288,6 +333,11 @@ func (r *Rethinkdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 		err  error
 	)
 
+	_, msgTable, err := msg.SplitNamespace()
+	if err != nil {
+		r.pipe.Err <- NewError(ERROR, r.path, fmt.Sprintf("rethinkdb error (msg namespace improperly formatted, must be database.table, got %s)", msg.Namespace), msg.Data)
+		return msg, nil
+	}
 	if !msg.IsMap() {
 		r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (document must be a json document)", msg.Data)
 		return msg, nil
@@ -301,11 +351,11 @@ func (r *Rethinkdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 			r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (cannot delete an object with a nil id)", msg.Data)
 			return msg, nil
 		}
-		resp, err = gorethink.Table(r.table).Get(id).Delete().RunWrite(r.client)
+		resp, err = gorethink.Table(msgTable).Get(id).Delete().RunWrite(r.client)
 	case message.Insert:
-		resp, err = gorethink.Table(r.table).Insert(doc).RunWrite(r.client)
+		resp, err = gorethink.Table(msgTable).Insert(doc).RunWrite(r.client)
 	case message.Update:
-		resp, err = gorethink.Table(r.table).Insert(doc, gorethink.InsertOpts{Conflict: "replace"}).RunWrite(r.client)
+		resp, err = gorethink.Table(msgTable).Insert(doc, gorethink.InsertOpts{Conflict: "replace"}).RunWrite(r.client)
 	}
 	if err != nil {
 		r.pipe.Err <- NewError(ERROR, r.path, "rethinkdb error (%s)", err)
@@ -318,14 +368,6 @@ func (r *Rethinkdb) applyOp(msg *message.Msg) (*message.Msg, error) {
 	}
 
 	return msg, nil
-}
-
-func (r *Rethinkdb) recreateTable() {
-	if r.debug {
-		fmt.Printf("dropping and creating table '%s' on database '%s'\n", r.table, r.database)
-	}
-	gorethink.DB(r.database).TableDrop(r.table).RunWrite(r.client)
-	gorethink.DB(r.database).TableCreate(r.table).RunWrite(r.client)
 }
 
 // handleresponse takes the rethink response and turn it into something we can consume elsewhere

--- a/pkg/adaptor/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb.go
@@ -317,7 +317,7 @@ func (r *Rethinkdb) prepareDocument(doc map[string]interface{}) map[string]inter
 
 // Listen start's the adaptor's listener
 func (r *Rethinkdb) Listen() (err error) {
-	return r.pipe.Listen(r.tableMatch, r.applyOp)
+	return r.pipe.Listen(r.applyOp, r.tableMatch)
 }
 
 // Stop the adaptor

--- a/pkg/adaptor/transformer.go
+++ b/pkg/adaptor/transformer.go
@@ -67,7 +67,7 @@ func NewTransformer(pipe *pipe.Pipe, path string, extra Config) (StopStartListen
 // transformers it into mejson, and then uses the supplied javascript module.exports function
 // to transform the document.  The document is then emited to this adaptor's children
 func (t *Transformer) Listen() (err error) {
-	return t.pipe.Listen(t.ns, t.transformOne)
+	return t.pipe.Listen(t.transformOne, t.ns)
 }
 
 // initEvironment prepares the javascript vm and compiles the transformer script

--- a/pkg/adaptor/transformer.go
+++ b/pkg/adaptor/transformer.go
@@ -67,7 +67,7 @@ func NewTransformer(pipe *pipe.Pipe, path string, extra Config) (StopStartListen
 // transformers it into mejson, and then uses the supplied javascript module.exports function
 // to transform the document.  The document is then emited to this adaptor's children
 func (t *Transformer) Listen() (err error) {
-	return t.pipe.Listen(t.transformOne)
+	return t.pipe.Listen(t.ns, t.transformOne)
 }
 
 // initEvironment prepares the javascript vm and compiles the transformer script
@@ -123,6 +123,7 @@ func (t *Transformer) transformOne(msg *message.Msg) (*message.Msg, error) {
 		"data": msg.Data,
 		"ts":   msg.Timestamp,
 		"op":   msg.Op.String(),
+		"ns":   msg.Namespace,
 	}
 	if msg.IsMap() {
 		if doc, err = mejson.Marshal(msg.Data); err != nil {
@@ -171,6 +172,7 @@ func (t *Transformer) toMsg(incoming interface{}, msg *message.Msg) error {
 	case map[string]interface{}: // we're a proper message.Msg, so copy the data over
 		msg.Op = message.OpTypeFromString(newMsg["op"].(string))
 		msg.Timestamp = newMsg["ts"].(int64)
+		msg.Namespace = newMsg["ns"].(string)
 
 		switch data := newMsg["data"].(type) {
 		case otto.Value:

--- a/pkg/message/message_test.go
+++ b/pkg/message/message_test.go
@@ -46,7 +46,7 @@ func TestIdString(t *testing.T) {
 	}
 
 	for _, v := range data {
-		msg := NewMsg(OpTypeFromString("insert"), v.in)
+		msg := NewMsg(OpTypeFromString("insert"), v.in, "database.collection")
 		id, err := msg.IDString(v.key)
 		if (err != nil) != v.err {
 			t.Errorf("expected error: %t, but got error: %v", v.err, err)

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -66,7 +66,7 @@ func NewPipe(pipe *Pipe, path string) *Pipe {
 // Listen starts a listening loop that pulls messages from the In chan, applies fn(msg), a `func(message.Msg) error`, and emits them on the Out channel.
 // Errors will be emited to the Pipe's Err chan, and will terminate the loop.
 // The listening loop can be interupted by calls to Stop().
-func (m *Pipe) Listen(nsFilter *regexp.Regexp, fn func(*message.Msg) (*message.Msg, error)) error {
+func (m *Pipe) Listen(fn func(*message.Msg) (*message.Msg, error), nsFilter *regexp.Regexp) error {
 	if m.In == nil {
 		return nil
 	}

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -7,6 +7,7 @@
 package pipe
 
 import (
+	"regexp"
 	"time"
 
 	"github.com/compose/transporter/pkg/events"
@@ -65,7 +66,7 @@ func NewPipe(pipe *Pipe, path string) *Pipe {
 // Listen starts a listening loop that pulls messages from the In chan, applies fn(msg), a `func(message.Msg) error`, and emits them on the Out channel.
 // Errors will be emited to the Pipe's Err chan, and will terminate the loop.
 // The listening loop can be interupted by calls to Stop().
-func (m *Pipe) Listen(fn func(*message.Msg) (*message.Msg, error)) error {
+func (m *Pipe) Listen(nsFilter *regexp.Regexp, fn func(*message.Msg) (*message.Msg, error)) error {
 	if m.In == nil {
 		return nil
 	}
@@ -84,19 +85,26 @@ func (m *Pipe) Listen(fn func(*message.Msg) (*message.Msg, error)) error {
 
 		select {
 		case msg := <-m.In:
+			if match, err := msg.MatchNamespace(nsFilter); !match || err != nil {
+				if err != nil {
+					m.Err <- err
+					return err
+				}
 
-			outmsg, err := fn(msg)
-			if err != nil {
-				m.Err <- err
-				return err
-			}
-			if skipMsg(outmsg) {
-				break
-			}
-			if len(m.Out) > 0 {
-				m.Send(outmsg)
 			} else {
-				m.MessageCount++ // update the count anyway
+				outmsg, err := fn(msg)
+				if err != nil {
+					m.Err <- err
+					return err
+				}
+				if skipMsg(outmsg) {
+					break
+				}
+				if len(m.Out) > 0 {
+					m.Send(outmsg)
+				} else {
+					m.MessageCount++ // update the count anyway
+				}
 			}
 		case <-time.After(100 * time.Millisecond):
 			// NOP, just breath

--- a/pkg/transporter/node_test.go
+++ b/pkg/transporter/node_test.go
@@ -16,8 +16,8 @@ func TestNodeString(t *testing.T) {
 			" - Source:                                                                                                 ",
 		},
 		{
-			NewNode("name", "mongodb", adaptor.Config{"uri": "uri", "namespace": "ns", "debug": false}),
-			" - Source:         name                                     mongodb         ns                             uri",
+			NewNode("name", "mongodb", adaptor.Config{"uri": "uri", "namespace": "db.col", "debug": false}),
+			" - Source:         name                                     mongodb         db.col                         uri",
 		},
 	}
 

--- a/pkg/transporter/pipeline_events_integration_test.go
+++ b/pkg/transporter/pipeline_events_integration_test.go
@@ -71,7 +71,10 @@ func TestEventsBroadcast(t *testing.T) {
 		t.FailNow()
 	}
 
-	p.Run()
+	err = p.Run()
+	if err != nil {
+		t.FailNow()
+	}
 
 	time.Sleep(time.Duration(5) * time.Second)
 

--- a/pkg/transporter/pipeline_integration_test.go
+++ b/pkg/transporter/pipeline_integration_test.go
@@ -34,7 +34,7 @@ func setupFiles(in, out string) {
 func setupMongo() {
 	// setup mongo
 	mongoSess, _ := mgo.Dial(mongoUri)
-	collection := mongoSess.DB("test").C("outColl")
+	collection := mongoSess.DB("testOut").C("coll")
 	collection.DropCollection()
 
 	for i := 0; i <= 5; i += 1 {
@@ -43,7 +43,7 @@ func setupMongo() {
 
 	mongoSess.Close()
 	mongoSess, _ = mgo.Dial(mongoUri)
-	collection = mongoSess.DB("test").C("inColl")
+	collection = mongoSess.DB("testIn").C("coll")
 	collection.DropCollection()
 	mongoSess.Close()
 }
@@ -99,8 +99,8 @@ func TestMongoToMongo(t *testing.T) {
 	setupMongo()
 
 	var (
-		inNs  = "test.inColl"
-		outNs = "test.outColl"
+		inNs  = "testIn.coll"
+		outNs = "testOut.coll"
 	)
 
 	// create the source node and attach our sink
@@ -128,8 +128,8 @@ func TestMongoToMongo(t *testing.T) {
 	}
 	defer mongoSess.Close()
 
-	collOut := mongoSess.DB("test").C("outColl")
-	collIn := mongoSess.DB("test").C("inColl")
+	collOut := mongoSess.DB("testOut").C("coll")
+	collIn := mongoSess.DB("testIn").C("coll")
 
 	// are the counts the same?
 	outCount, _ := collOut.Count()
@@ -155,7 +155,7 @@ func TestMongoToMongo(t *testing.T) {
 	}
 
 	// clean up
-	mongoSess.DB("test").C("outColl").DropCollection()
-	mongoSess.DB("test").C("inColl").DropCollection()
+	mongoSess.DB("testOut").C("coll").DropCollection()
+	mongoSess.DB("testIn").C("coll").DropCollection()
 
 }


### PR DESCRIPTION
Addresses https://github.com/compose/transporter/issues/78 based on implementation discussed in https://github.com/compose/transporter/issues/23

The following allows for processing more than 1 collection/table at a time. The current Source adaptors, MongoDB and RethinkDB, have been updated to properly handle this change but the RethinkDB adaptor does NOT automagically pick up new tables added to the database.

An example of how one could pick and choose what namespaces they wanted to sync:

```javascript
pipeline = Source({name:"foofile", namespace: "database./(bas|baz)/"})

pipeline.save({name:"localmongo", namespace: "boom.bas"})
pipeline.save({name:"locales", namespace: "boom.baz"})
```

You can also create transformers in the pipeline which have access to the namespace if you need to alert it inflight.