### PR TITLE
Vagrant up transporter

### DIFF
--- a/.ansible-provision.yml
+++ b/.ansible-provision.yml
@@ -47,16 +47,5 @@
         owner=vagrant
         group=vagrant
 
-    - name: some test data
-      shell: "{{ item }}"
-      with_items:
-        - mongo --eval 'use foo; db.bar.save({"firstName": "Robert", "lastName": "Baratheon"});'
-        - mongo --eval 'use foo; db.bar.save({"firstName": "John", "lastName": "Snow"});'
-
-
-     #db.bar.find().pretty();
-     #transporter run --config ./config.yaml ./application.js
-     #curl -XGET localhost:9200/foo/bar/_search?pretty=true
-
 
 

--- a/.ansible-provision.yml
+++ b/.ansible-provision.yml
@@ -42,10 +42,17 @@
   tasks:
     - name: copy simple test files
       copy:
-        src=./simple/
+        src=./test/simple/
         dest=/home/vagrant
         owner=vagrant
         group=vagrant
 
+    - name: make run-test executable
+      file:
+        state=file
+        path=/home/vagrant/run-test
+        owner=vagrant
+        group=vagrant
+        mode=0775
 
 

--- a/.ansible-provision.yml
+++ b/.ansible-provision.yml
@@ -1,0 +1,62 @@
+---
+- hosts: all
+  sudo: true
+
+  pre_tasks:
+    - name: dependecies
+      apt: name={{ item }}
+      sudo: true
+      with_items:
+        - rsync
+
+  roles:
+    - role: gotansible.mongodb
+
+    - role: gotansible.elasticsearch
+      elasticsearch_node_name: "{{ inventory_hostname }}"
+      elasticsearch_cluster_name: test-solo
+
+      elasticsearch_node_data: true
+      elasticsearch_node_master: true
+      elasticsearch_http_enabled: true
+
+      elasticsearch_discovery_zen_minimum_master_nodes: 1
+      elasticsearch_discovery_zen_ping_multicast_enabled: false
+      elasticsearch_discovery_zen_ping_unicast_hosts:
+        - "{{ ansible_default_ipv4['address'] }}"
+
+      elasticsearch_index_number_of_shards: 2
+      elasticsearch_index_number_of_replicas: 1
+
+    - role: gotansible.gobuild
+      gobuild_project_path: github.com/compose/transporter
+      gobuild_repo_version: master
+      gobuild_dir: /home/vagrant/go
+      gobuild_commands:
+        - go get github.com/tools/godep
+        - godep restore
+        - godep go build -a ./cmd/...
+        - mv ./transporter /home/vagrant
+        - chown -R vagrant:vagrant /home/vagrant/
+
+  tasks:
+    - name: copy simple test files
+      copy:
+        src=./simple/
+        dest=/home/vagrant
+        owner=vagrant
+        group=vagrant
+
+    - name: some test data
+      shell: "{{ item }}"
+      with_items:
+        - mongo --eval 'use foo; db.bar.save({"firstName": "Robert", "lastName": "Baratheon"});'
+        - mongo --eval 'use foo; db.bar.save({"firstName": "John", "lastName": "Snow"});'
+
+
+     #db.bar.find().pretty();
+     #transporter run --config ./config.yaml ./application.js
+     #curl -XGET localhost:9200/foo/bar/_search?pretty=true
+
+
+

--- a/.ansible-requirements.yml
+++ b/.ansible-requirements.yml
@@ -1,0 +1,11 @@
+---
+
+- src: https://github.com/gotansible/mongodb
+  name: gotansible.mongodb
+
+- src: https://github.com/gotansible/elasticsearch
+  name: gotansible.elasticsearch
+
+- src: https://github.com/gotansible/gobuild
+  name: gotansible.gobuild
+

--- a/README.md
+++ b/README.md
@@ -83,6 +83,22 @@ Complete beginners guide
 
 At this point you should be able to run transporter via `$GOPATH/bin/transporter`,  you may need to add $GOPATH to your PATH environment variable. Something along the lines of `export PATH="$GOPATH/bin:$PATH"` should work.
 
+### Vagrant
+
+* ensure [vagrant](https://www.vagrantup.com/) is installed
+* ensure [ansible](http://www.ansible.com/) is installed
+* ensure either [virtual box](https://www.virtualbox.org/wiki/Downloads) or [VMWare fusion](http://www.vmware.com/products/fusion) or [VMWare Workstation](http://www.vmware.com/products/workstation) is installed
+
+```bash
+> cd transporter
+> vagrant up
+...
+> vagrant ssh
+...
+vagrant> ./run-test
+
+```
+
 ### Windows
 
 See [READMEWINDOWS.md](https://github.com/compose/transporter/blob/master/READMEWINDOWS.md)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,25 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+system("
+    if [ #{ARGV[0]} = 'up' ]; then
+		ansible-galaxy install -r .ansible-requirements.yml --force
+    fi
+")
+
+VAGRANT_VERSION = 2
+Vagrant.configure(VAGRANT_VERSION) do |config|
+	config.vm.provider "vmware_fusion" do |v|
+		v.vmx["memsize"] = "2048"
+	end
+	config.vm.provider "virtualbox" do |v|
+		v.memory = 2048
+	end
+
+	config.vm.define "transporter-demo" do |server|
+		server.vm.box = "hashicorp/precise64"
+		server.vm.hostname = "transporter-demo"
+		server.vm.provision :ansible do |ansible|
+			ansible.playbook = ".ansible-provision.yml"
+		end
+	end
+end

--- a/test/simple/application.js
+++ b/test/simple/application.js
@@ -1,0 +1,1 @@
+Source({name:"localmongo", namespace:"foo.bar"}).save({name:"es", namespace:"foo.bar"});

--- a/test/simple/config.yml
+++ b/test/simple/config.yml
@@ -1,0 +1,21 @@
+# api:
+#   interval: 60s
+#   uri: "http://requestb.in/13gerls1"
+#   key: "48593282-b38d-4bf5-af58-f7327271e73d"
+#   pid: "something-static"
+nodes:
+  localmongo:
+    type: mongo
+    uri: mongodb://localhost/foo
+  es:
+    type: elasticsearch
+    uri: http://localhost:9200/
+  timeseries:
+    type: influx
+    uri: influxdb://root:root@localhost:8086/compose
+  debug:
+    type: file
+    uri: stdout://
+  foofile:
+    type: file
+    uri: file:///tmp/foo

--- a/test/simple/run-test
+++ b/test/simple/run-test
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+mongo --eval 'use foo; db.bar.save({"firstName": "Robert", "lastName": "Baratheon"});'
+mongo --eval 'use foo; db.bar.save({"firstName": "John", "lastName": "Snow"});'
+
+echo "mongo --eval 'use foo; db.bar.find().pretty();'"
+mongo --eval 'use foo; db.bar.find().pretty();'
+
+echo "transporter run --config ./config.yaml ./application.js"
+transporter run --config ./config.yaml ./application.js
+
+echo "curl -XGET localhost:9200/foo/bar/_search?pretty=true"
+curl -XGET localhost:9200/foo/bar/_search?pretty=true
+
+

--- a/test/simple/run-test
+++ b/test/simple/run-test
@@ -1,15 +1,19 @@
 #!/bin/bash
 
-mongo --eval 'use foo; db.bar.save({"firstName": "Robert", "lastName": "Baratheon"});'
-mongo --eval 'use foo; db.bar.save({"firstName": "John", "lastName": "Snow"});'
+mongo --eval 'db.bar.save({"firstName": "Robert", "lastName": "Baratheon"});' foo
+mongo --eval 'db.bar.save({"firstName": "John", "lastName": "Snow"});' foo
 
-echo "mongo --eval 'use foo; db.bar.find().pretty();'"
-mongo --eval 'use foo; db.bar.find().pretty();'
+echo ""
+echo "run the following to see the mongo data:"
+echo ""
+echo "mongo"
+echo "use foo"
+echo "db.bar.find().pretty();"
+echo ""
 
 echo "transporter run --config ./config.yaml ./application.js"
 transporter run --config ./config.yaml ./application.js
 
+echo ""
 echo "curl -XGET localhost:9200/foo/bar/_search?pretty=true"
 curl -XGET localhost:9200/foo/bar/_search?pretty=true
-
-


### PR DESCRIPTION
Enables one to just type:

```
> vagrant up
```

and have a fully configured VM with Mongo, ElasticSearch and Compose, with a ready to run demo.