### PR TITLE
FIX: delete `_id` key to allow elastic insertions

### DIFF
--- a/pkg/adaptor/elasticsearch.go
+++ b/pkg/adaptor/elasticsearch.go
@@ -109,6 +109,7 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 	if err != nil {
 		id = ""
 	}
+	delete(msg.Map(), "_id")
 
 	_, _type, err := msg.SplitNamespace()
 	if err != nil {


### PR DESCRIPTION
This addresses issues https://github.com/compose/transporter/issues/165 and https://github.com/compose/transporter/issues/167.
