### PR TITLE
Fixes #154 - Allow transformers to chain

### DIFF
--- a/cmd/transporter/node.go
+++ b/cmd/transporter/node.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/compose/transporter/pkg/adaptor"
@@ -13,12 +14,13 @@ import (
 // Node is a struct modelled after the transporter.Node struct, but
 // more easily able to serialize to json for to use within the application.js
 type Node struct {
-	UUID     string
-	Name     string         `json:"name"`
-	Type     string         `json:"type"`
-	Extra    adaptor.Config `json:"extra"`
-	Children []*Node        `json:"children"`
-	RootUUID string
+	UUID       string
+	Name       string         `json:"name"`
+	Type       string         `json:"type"`
+	Extra      adaptor.Config `json:"extra"`
+	Children   []*Node        `json:"children"`
+	RootUUID   string
+	ParentUUID string
 }
 
 // NewNode creates a node
@@ -28,7 +30,7 @@ func NewNode(name, kind string, extra adaptor.Config) (node Node, err error) {
 		return node, err
 	}
 
-	return Node{UUID: uuid.String(), Name: name, Type: kind, Extra: extra, RootUUID: uuid.String(), Children: make([]*Node, 0)}, nil
+	return Node{UUID: uuid.String(), Name: name, Type: kind, Extra: extra, RootUUID: uuid.String(), Children: make([]*Node, 0), ParentUUID: uuid.String()}, nil
 }
 
 // CreateNode creates a node by marshalling an interface to json,
@@ -60,7 +62,28 @@ func (n *Node) Object() (*otto.Object, error) {
 // Add will add a node as a child of the current node
 func (n *Node) Add(node *Node) {
 	node.RootUUID = n.RootUUID
+	node.ParentUUID = n.UUID
 	n.Children = append(n.Children, node)
+}
+
+// Find a child node, depth first search
+func (n *Node) Find(childUUID string) (node *Node, err error) {
+	if n.UUID == childUUID {
+		return n, nil
+	}
+	for _, child := range n.Children {
+		if child.UUID == childUUID {
+			return child, nil
+		} else {
+			found, err := child.Find(childUUID)
+			if err != nil {
+				continue
+			} else {
+				return found, nil
+			}
+		}
+	}
+	return nil, errors.New(fmt.Sprintf("child %s not found under %s", childUUID, n.UUID))
 }
 
 // CreateTransporterNode will turn this node into a transporter.Node.

--- a/cmd/transporter/node_test.go
+++ b/cmd/transporter/node_test.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"github.com/compose/transporter/pkg/adaptor"
+	"testing"
+)
+
+func TestFind(t *testing.T) {
+	// build a tree to run tests on
+	//   root
+	//   /  \
+	// c1    c2
+	//  |
+	// c1c1
+	root, _ := NewNode("root", "test", adaptor.Config{})
+	c1, _ := NewNode("c1", "test", adaptor.Config{})
+	c2, _ := NewNode("c2", "test", adaptor.Config{})
+	c1c1, _ := NewNode("c1c1", "test", adaptor.Config{})
+
+	root.Add(&c1)
+	root.Add(&c2)
+	c1.Add(&c1c1)
+
+	data := []struct {
+		description string
+		in          Node
+		searchUUID  string
+		out         Node
+		pass        bool
+		err         error
+	}{
+		{
+			"find root from root node",
+			root,
+			root.UUID,
+			root,
+			true,
+			errors.New(""),
+		},
+		{
+			"find c1 from root node",
+			root,
+			c1.UUID,
+			c1,
+			true,
+			errors.New(""),
+		},
+		{
+			"find c2 from root node",
+			root,
+			c2.UUID,
+			c2,
+			true,
+			errors.New(""),
+		},
+		{
+			"find c2 from c1",
+			c1,
+			c2.UUID,
+			c2,
+			false,
+			errors.New(fmt.Sprintf("child %s not found under %s", c2.UUID, c1.UUID)),
+		},
+		{
+			"find c1c1 from root",
+			root,
+			c1c1.UUID,
+			c1c1,
+			true,
+			errors.New(""),
+		},
+		{
+			"find c1c1 from c1",
+			c1,
+			c1c1.UUID,
+			c1c1,
+			true,
+			errors.New(""),
+		},
+		{
+			"find c1c1 from c2",
+			c2,
+			c1c1.UUID,
+			c1c1,
+			false,
+			errors.New(fmt.Sprintf("child %s not found under %s", c1c1.UUID, c2.UUID)),
+		},
+	}
+
+	for _, v := range data {
+		res, err := v.in.Find(v.searchUUID)
+		if v.pass && (err == nil) {
+			if res.Name != v.out.Name {
+				t.Errorf("%s: found %s expected %s", v.description, res.Name, v.in.Name)
+			}
+		} else {
+			if err != nil && err.Error() != v.err.Error() {
+				t.Errorf("%s: %s expected %s", v.description, err, v.err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Attempting to use more than one transformer in a pipeline resulted in
only the last transformer being added to the pipeline's node tree.
Previous transformers were created but not persisted.

As noted in #154, a chain like:

    Source().transformer().transformer().save()

resulted in only the final transformer running.

I used gdb to inspect the resulting source tree in pkg/transporter/pipeline.go.  Given the above pipeline as input, the tree built looked like:

    root -> transformer2 -> save

The first transformer was not part of the tree.

Before this change, the save method of javascript_builder.go was only set up to handle a 3-level tree.

This change uses the new Node.Find method to attach the node to the correct
portion of the tree below the root node.

Unit tests are included for the Find method.

I have verified that chaining multiple transformers now works correctly.  I was unable to get specific information from #compose IRC users about how to verify all existing tests are passing.  Please advise.

Note that even though it is now possible to build a pipeline with multiple transformers chained in order, results seem unpredictable/broken when the pipeline is split.  I am not familiar enough with transporter to know whether that is intended behavior or not.