### PR TITLE
refactor: use func init to register adaptors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
-transporter
-!cmd/transporter
-!pkg/transporter
-
+/transporter

--- a/cmd/transporter/command.go
+++ b/cmd/transporter/command.go
@@ -233,17 +233,27 @@ func (c *aboutCommand) Synopsis() string {
 func (c *aboutCommand) Run(args []string) int {
 
 	if len(args) == 0 {
-		for _, a := range adaptor.Adaptors {
-			fmt.Printf("%-20s %s\n", a.Name, a.Description)
+		for name, creator := range adaptor.Adaptors {
+			dummyAdaptor, err := creator(nil, "", map[string]interface{}{"uri": "test", "namespace": "test.test"})
+			if err != nil {
+				fmt.Printf("unable to create adator '%s', %s\n", name, err.Error())
+				return 1
+			}
+			fmt.Printf("%-20s %s\n", name, dummyAdaptor.Description())
 		}
 		return 0
 	}
 
-	a, ok := adaptor.Adaptors[args[0]]
+	creator, ok := adaptor.Adaptors[args[0]]
 	if !ok {
 		fmt.Printf("no adaptor named '%s' exists\n", args[0])
 		return 1
 	}
-	fmt.Print(a.About())
+	dummyAdaptor, err := creator(nil, "", map[string]interface{}{"uri": "test", "namespace": "test.test"})
+	if err != nil {
+		fmt.Printf("unable to create adator, %s\n", err.Error())
+		return 1
+	}
+	fmt.Println(dummyAdaptor.Description())
 	return 0
 }

--- a/cmd/transporter/command.go
+++ b/cmd/transporter/command.go
@@ -234,7 +234,7 @@ func (c *aboutCommand) Run(args []string) int {
 
 	if len(args) == 0 {
 		for name, creator := range adaptor.Adaptors {
-			dummyAdaptor, err := creator(nil, "", map[string]interface{}{"uri": "test", "namespace": "test.test"})
+			dummyAdaptor, err := creator(nil, "", adaptor.Config{"uri": "test", "namespace": "test.test"})
 			if err != nil {
 				fmt.Printf("unable to create adator '%s', %s\n", name, err.Error())
 				return 1
@@ -249,7 +249,7 @@ func (c *aboutCommand) Run(args []string) int {
 		fmt.Printf("no adaptor named '%s' exists\n", args[0])
 		return 1
 	}
-	dummyAdaptor, err := creator(nil, "", map[string]interface{}{"uri": "test", "namespace": "test.test"})
+	dummyAdaptor, err := creator(nil, "", adaptor.Config{"uri": "test", "namespace": "test.test"})
 	if err != nil {
 		fmt.Printf("unable to create adator, %s\n", err.Error())
 		return 1

--- a/cmd/transporter/javascript_builder.go
+++ b/cmd/transporter/javascript_builder.go
@@ -257,7 +257,6 @@ func (js *JavascriptBuilder) Build() error {
 
 	var sessionStore state.SessionStore
 	sessionInterval := time.Duration(10 * time.Second)
-	fmt.Printf("js sessions config -> %v\n", js.config.Sessions)
 	if js.config.Sessions.SessionInterval != "" {
 		sessionInterval, err = time.ParseDuration(js.config.Sessions.SessionInterval)
 		if err != nil {

--- a/cmd/transporter/main.go
+++ b/cmd/transporter/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 
+	_ "github.com/compose/transporter/pkg/adaptor/all"
 	"github.com/compose/transporter/pkg/transporter"
 	"github.com/mitchellh/cli"
 )

--- a/pkg/adaptor/adaptor.go
+++ b/pkg/adaptor/adaptor.go
@@ -19,6 +19,9 @@ func (a ErrAdaptor) Error() string {
 }
 
 // StopStartListener defines the interface that all database connectors and nodes must follow.
+// SampleConfig() returns an example YAML structure to configure the adaptor
+// Description() provides contextual information for what the adaptor is for
+// Connect() allows the adaptor an opportunity to setup connections prior to Start()
 // Start() consumes data from the interface,
 // Listen() listens on a pipe, processes data, and then emits it.
 // Stop() shuts down the adaptor

--- a/pkg/adaptor/adaptor_test.go
+++ b/pkg/adaptor/adaptor_test.go
@@ -13,12 +13,26 @@ type Testadaptor struct {
 	value string
 }
 
-func NewTestadaptor(p *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
-	val, ok := extra["value"]
-	if !ok {
-		return nil, errors.New("this is an error")
-	}
-	return &Testadaptor{value: val.(string)}, nil
+func init() {
+	Add("testadaptor", func(p *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
+		val, ok := extra["value"]
+		if !ok {
+			return nil, errors.New("this is an error")
+		}
+		return &Testadaptor{value: val.(string)}, nil
+	})
+}
+
+func (s *Testadaptor) Description() string {
+	return "this is a test adaptor"
+}
+
+func (s *Testadaptor) SampleConfig() string {
+	return ""
+}
+
+func (s *Testadaptor) Connect() error {
+	return nil
 }
 
 func (s *Testadaptor) Start() error {
@@ -34,8 +48,6 @@ func (s *Testadaptor) Listen() error {
 }
 
 func TestCreateadaptor(t *testing.T) {
-	Register("testadaptor", "description", NewTestadaptor, struct{}{})
-
 	data := []struct {
 		kind  string
 		extra Config
@@ -52,7 +64,7 @@ func TestCreateadaptor(t *testing.T) {
 			"testadaptor",
 			Config{"blah": "rockettes"},
 			&Testadaptor{},
-			"cannot create testadaptor adaptor (a/b/c). this is an error",
+			"adaptor 'testadaptor' not found in registry",
 		},
 		{
 			"notasource",

--- a/pkg/adaptor/all/all.go
+++ b/pkg/adaptor/all/all.go
@@ -1,0 +1,9 @@
+package all
+
+import (
+	_ "github.com/compose/transporter/pkg/adaptor/elasticsearch"
+	_ "github.com/compose/transporter/pkg/adaptor/file"
+	_ "github.com/compose/transporter/pkg/adaptor/mongodb"
+	_ "github.com/compose/transporter/pkg/adaptor/rethinkdb"
+	_ "github.com/compose/transporter/pkg/adaptor/transformer"
+)

--- a/pkg/adaptor/elasticsearch/elasticsearch.go
+++ b/pkg/adaptor/elasticsearch/elasticsearch.go
@@ -1,4 +1,4 @@
-package adaptor
+package elasticsearch
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/compose/transporter/pkg/adaptor"
 	"github.com/compose/transporter/pkg/message"
 	"github.com/compose/transporter/pkg/pipe"
 	elastigo "github.com/mattbaird/elastigo/lib"
@@ -27,33 +28,53 @@ type Elasticsearch struct {
 	running bool
 }
 
-// NewElasticsearch creates a new Elasticsearch adaptor.
-// Elasticsearch adaptors cannot be used as a source,
-func NewElasticsearch(p *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
-	var (
-		conf dbConfig
-		err  error
-	)
-	if err = extra.Construct(&conf); err != nil {
-		return nil, NewError(CRITICAL, path, fmt.Sprintf("bad config (%s)", err.Error()), nil)
-	}
+// Description for elasticsearch adaptor
+func (e *Elasticsearch) Description() string {
+	return "an elasticsearch sink adaptor"
+}
 
-	u, err := url.Parse(conf.URI)
-	if err != nil {
-		return nil, err
-	}
+var sampleConfig = `
+- es:
+		type: elasticsearch
+    uri: https://username:password@hostname:port/thisgetsignored
+`
 
-	e := &Elasticsearch{
-		uri:  u,
-		pipe: p,
-	}
+// SampleConfig for elasticsearch adaptor
+func (e *Elasticsearch) SampleConfig() string {
+	return sampleConfig
+}
 
-	e.index, e.typeMatch, err = extra.compileNamespace()
-	if err != nil {
-		return e, NewError(CRITICAL, path, fmt.Sprintf("can't split namespace into _index and typeMatch (%s)", err.Error()), nil)
-	}
+func init() {
+	adaptor.Add("elasticsearch", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
+		var (
+			conf adaptor.DbConfig
+			err  error
+		)
+		if err = extra.Construct(&conf); err != nil {
+			return nil, adaptor.NewError(adaptor.CRITICAL, path, fmt.Sprintf("bad config (%s)", err.Error()), nil)
+		}
 
-	return e, nil
+		u, err := url.Parse(conf.URI)
+		if err != nil {
+			return nil, err
+		}
+
+		e := &Elasticsearch{
+			uri:  u,
+			pipe: p,
+		}
+
+		e.index, e.typeMatch, err = extra.CompileNamespace()
+		if err != nil {
+			return e, adaptor.NewError(adaptor.CRITICAL, path, fmt.Sprintf("can't split namespace into _index and typeMatch (%s)", err.Error()), nil)
+		}
+
+		return e, nil
+	})
+}
+
+func (e *Elasticsearch) Connect() error {
+	return nil
 }
 
 // Start the adaptor as a source (not implemented)
@@ -69,7 +90,7 @@ func (e *Elasticsearch) Listen() error {
 
 	go func(cherr chan *elastigo.ErrorBuffer) {
 		for err := range e.indexer.ErrorChannel {
-			e.pipe.Err <- NewError(CRITICAL, e.path, fmt.Sprintf("elasticsearch error (%s)", err.Err), nil)
+			e.pipe.Err <- adaptor.NewError(adaptor.CRITICAL, e.path, fmt.Sprintf("elasticsearch error (%s)", err.Err), nil)
 		}
 	}(e.indexer.ErrorChannel)
 
@@ -98,7 +119,7 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 	if msg.Op == message.Command {
 		err := e.runCommand(msg)
 		if err != nil {
-			e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
+			e.pipe.Err <- adaptor.NewError(adaptor.ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
 		}
 		return msg, nil
 	}
@@ -112,7 +133,7 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 
 	_, _type, err := msg.SplitNamespace()
 	if err != nil {
-		e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("unable to determine type from msg.Namespace (%s)", msg.Namespace), msg)
+		e.pipe.Err <- adaptor.NewError(adaptor.ERROR, e.path, fmt.Sprintf("unable to determine type from msg.Namespace (%s)", msg.Namespace), msg)
 		return msg, nil
 	}
 	switch msg.Op {
@@ -123,7 +144,7 @@ func (e *Elasticsearch) applyOp(msg *message.Msg) (*message.Msg, error) {
 		err = e.indexer.Index(e.index, _type, id, "", "", nil, msg.Data, false)
 	}
 	if err != nil {
-		e.pipe.Err <- NewError(ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
+		e.pipe.Err <- adaptor.NewError(adaptor.ERROR, e.path, fmt.Sprintf("elasticsearch error (%s)", err), msg.Data)
 	}
 	return msg, nil
 }

--- a/pkg/adaptor/file/file.go
+++ b/pkg/adaptor/file/file.go
@@ -1,4 +1,4 @@
-package adaptor
+package file
 
 import (
 	"encoding/json"
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/compose/transporter/pkg/adaptor"
 	"github.com/compose/transporter/pkg/message"
 	"github.com/compose/transporter/pkg/pipe"
 )
@@ -21,21 +22,42 @@ type File struct {
 	filehandle *os.File
 }
 
-// NewFile returns a File Adaptor
-func NewFile(p *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
-	var (
-		conf FileConfig
-		err  error
-	)
-	if err = extra.Construct(&conf); err != nil {
-		return nil, NewError(CRITICAL, path, fmt.Sprintf("Can't configure adaptor (%s)", err.Error()), nil)
-	}
+// Description for file adaptor
+func (f *File) Description() string {
+	return "an adaptor that reads / writes files"
+}
 
-	return &File{
-		uri:  conf.URI,
-		pipe: p,
-		path: path,
-	}, nil
+var sampleConfig = `
+- stdout:
+    type: file
+    uri: stdout://
+`
+
+// SampleConfig for file adaptor
+func (f *File) SampleConfig() string {
+	return sampleConfig
+}
+
+func init() {
+	adaptor.Add("file", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
+		var (
+			conf fileConfig
+			err  error
+		)
+		if err = extra.Construct(&conf); err != nil {
+			return nil, adaptor.NewError(adaptor.CRITICAL, path, fmt.Sprintf("Can't configure adaptor (%s)", err.Error()), nil)
+		}
+
+		return &File{
+			uri:  conf.URI,
+			pipe: p,
+			path: path,
+		}, nil
+	})
+}
+
+func (f *File) Connect() error {
+	return nil
 }
 
 // Start the file adaptor
@@ -58,7 +80,7 @@ func (d *File) Listen() (err error) {
 		filename := strings.Replace(d.uri, "file://", "", 1)
 		d.filehandle, err = os.Create(filename)
 		if err != nil {
-			d.pipe.Err <- NewError(CRITICAL, d.path, fmt.Sprintf("Can't open output file (%s)", err.Error()), nil)
+			d.pipe.Err <- adaptor.NewError(adaptor.CRITICAL, d.path, fmt.Sprintf("Can't open output file (%s)", err.Error()), nil)
 			return err
 		}
 	}
@@ -77,7 +99,7 @@ func (d *File) readFile() (err error) {
 	filename := strings.Replace(d.uri, "file://", "", 1)
 	d.filehandle, err = os.Open(filename)
 	if err != nil {
-		d.pipe.Err <- NewError(CRITICAL, d.path, fmt.Sprintf("Can't open input file (%s)", err.Error()), nil)
+		d.pipe.Err <- adaptor.NewError(adaptor.CRITICAL, d.path, fmt.Sprintf("Can't open input file (%s)", err.Error()), nil)
 		return err
 	}
 
@@ -87,7 +109,7 @@ func (d *File) readFile() (err error) {
 		if err := decoder.Decode(&doc); err == io.EOF {
 			break
 		} else if err != nil {
-			d.pipe.Err <- NewError(ERROR, d.path, fmt.Sprintf("Can't marshal document (%s)", err.Error()), nil)
+			d.pipe.Err <- adaptor.NewError(adaptor.ERROR, d.path, fmt.Sprintf("Can't marshal document (%s)", err.Error()), nil)
 			return err
 		}
 		d.pipe.Send(message.NewMsg(message.Insert, doc, fmt.Sprintf("file.%s", filename)))
@@ -104,7 +126,7 @@ func (d *File) dumpMessage(msg *message.Msg) (*message.Msg, error) {
 	if msg.IsMap() {
 		ba, err := json.Marshal(msg.Map())
 		if err != nil {
-			d.pipe.Err <- NewError(ERROR, d.path, fmt.Sprintf("Can't unmarshal document (%s)", err.Error()), msg.Data)
+			d.pipe.Err <- adaptor.NewError(adaptor.ERROR, d.path, fmt.Sprintf("Can't unmarshal document (%s)", err.Error()), msg.Data)
 			return msg, nil
 		}
 		line = string(ba)
@@ -117,7 +139,7 @@ func (d *File) dumpMessage(msg *message.Msg) (*message.Msg, error) {
 	} else {
 		_, err := fmt.Fprintln(d.filehandle, line)
 		if err != nil {
-			d.pipe.Err <- NewError(ERROR, d.path, fmt.Sprintf("Error writing to file (%s)", err.Error()), msg.Data)
+			d.pipe.Err <- adaptor.NewError(adaptor.ERROR, d.path, fmt.Sprintf("Error writing to file (%s)", err.Error()), msg.Data)
 			return msg, nil
 		}
 	}
@@ -125,8 +147,8 @@ func (d *File) dumpMessage(msg *message.Msg) (*message.Msg, error) {
 	return msg, nil
 }
 
-// FileConfig is used to configure the File Adaptor,
-type FileConfig struct {
+// fileConfig is used to configure the File Adaptor
+type fileConfig struct {
 	// URI pointing to the resource.  We only recognize file:// and stdout:// currently
 	URI string `json:"uri" doc:"the uri to connect to, ie stdout://, file:///tmp/output"`
 }

--- a/pkg/adaptor/file/file.go
+++ b/pkg/adaptor/file/file.go
@@ -41,7 +41,7 @@ func (f *File) SampleConfig() string {
 func init() {
 	adaptor.Add("file", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
 		var (
-			conf fileConfig
+			conf Config
 			err  error
 		)
 		if err = extra.Construct(&conf); err != nil {
@@ -147,8 +147,8 @@ func (d *File) dumpMessage(msg *message.Msg) (*message.Msg, error) {
 	return msg, nil
 }
 
-// fileConfig is used to configure the File Adaptor
-type fileConfig struct {
+// Config is used to configure the File Adaptor
+type Config struct {
 	// URI pointing to the resource.  We only recognize file:// and stdout:// currently
 	URI string `json:"uri" doc:"the uri to connect to, ie stdout://, file:///tmp/output"`
 }

--- a/pkg/adaptor/influxdb/influxdb.go
+++ b/pkg/adaptor/influxdb/influxdb.go
@@ -1,4 +1,4 @@
-package adaptor
+package influxdb
 
 /*
  * Influx is awesome, but unfortunately the pre-0.9 changes

--- a/pkg/adaptor/mongodb/mongodb.go
+++ b/pkg/adaptor/mongodb/mongodb.go
@@ -29,7 +29,7 @@ type Mongodb struct {
 	uri   string
 	tail  bool // run the tail oplog
 	debug bool
-	conf  mongodbConfig
+	conf  Config
 
 	// save time by setting these once
 	collectionMatch *regexp.Regexp
@@ -84,7 +84,7 @@ func (m *Mongodb) SampleConfig() string {
 func init() {
 	adaptor.Add("mongodb", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
 		var (
-			conf mongodbConfig
+			conf Config
 			err  error
 		)
 		if err = extra.Construct(&conf); err != nil {
@@ -517,13 +517,13 @@ func (o *oplogDoc) validOp() bool {
 	return o.Op == "i" || o.Op == "d" || o.Op == "u"
 }
 
-// mongodbConfig provides configuration options for a mongodb adaptor
+// Config provides configuration options for a mongodb adaptor
 // the notable difference between this and dbConfig is the presence of the Tail option
-type mongodbConfig struct {
+type Config struct {
 	URI       string     `json:"uri" doc:"the uri to connect to, in the form mongodb://user:password@host.com:27017/auth_database"`
 	Namespace string     `json:"namespace" doc:"mongo namespace to read/write"`
 	Ssl       *sslConfig `json:"ssl,omitempty" doc:"ssl options for connection"`
-	Timeout   string     `json:timeout" doc:"timeout for establishing connection, format must be parsable by time.ParseDuration and defaults to 10s"`
+	Timeout   string     `json:"timeout" doc:"timeout for establishing connection, format must be parsable by time.ParseDuration and defaults to 10s"`
 	Debug     bool       `json:"debug" doc:"display debug information"`
 	Tail      bool       `json:"tail" doc:"if tail is true, then the mongodb source will tail the oplog after copying the namespace"`
 	Wc        int        `json:"wc" doc:"The write concern to use for writes, Int, indicating the minimum number of servers to write to before returning success/failure"`

--- a/pkg/adaptor/mongodb/mongodb.go
+++ b/pkg/adaptor/mongodb/mongodb.go
@@ -1,4 +1,4 @@
-package adaptor
+package mongodb
 
 import (
 	"crypto/tls"
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/compose/transporter/pkg/adaptor"
 	"github.com/compose/transporter/pkg/message"
 	"github.com/compose/transporter/pkg/pipe"
 	"gopkg.in/mgo.v2"
@@ -28,6 +29,7 @@ type Mongodb struct {
 	uri   string
 	tail  bool // run the tail oplog
 	debug bool
+	conf  mongodbConfig
 
 	// save time by setting these once
 	collectionMatch *regexp.Regexp
@@ -40,8 +42,9 @@ type Mongodb struct {
 	path string
 
 	// mongo connection and options
-	mongoSession *mgo.Session
-	oplogTimeout time.Duration
+	mongoSession   *mgo.Session
+	sessionTimeout time.Duration
+	oplogTimeout   time.Duration
 
 	// a buffer to hold documents
 	buffLock         sync.Mutex
@@ -60,57 +63,91 @@ type SyncDoc struct {
 	Collection string
 }
 
-// NewMongodb creates a new Mongodb adaptor
-func NewMongodb(p *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
-	var (
-		conf MongodbConfig
-		err  error
-	)
-	if err = extra.Construct(&conf); err != nil {
-		return nil, err
-	}
+// Description for mongodb adaptor
+func (m *Mongodb) Description() string {
+	return "a mongodb adaptor that functions as both a source and a sink"
+}
 
-	if conf.URI == "" || conf.Namespace == "" {
-		return nil, fmt.Errorf("both uri and namespace required, but missing ")
-	}
+var sampleConfig = `
+- localmongo:
+    type: mongo
+    uri: mongodb://127.0.0.1:27017/test
+    namespace: test.data
+    debug: true
+`
 
-	if conf.Debug {
-		fmt.Printf("Mongo Config %+v\n", conf)
-	}
+// SampleConfig for mongodb adaptor
+func (m *Mongodb) SampleConfig() string {
+	return sampleConfig
+}
 
-	m := &Mongodb{
-		restartable:      true,            // assume for that we're able to restart the process
-		oplogTimeout:     5 * time.Second, // timeout the oplog iterator
-		pipe:             p,
-		uri:              conf.URI,
-		tail:             conf.Tail,
-		debug:            conf.Debug,
-		path:             path,
-		opsBuffer:        make(map[string][]interface{}),
-		bulkWriteChannel: make(chan *SyncDoc),
-		bulkQuitChannel:  make(chan chan bool),
-		bulk:             conf.Bulk,
-	}
-	// opsBuffer:        make([]*SyncDoc, 0, MONGO_BUFFER_LEN),
+func init() {
+	adaptor.Add("mongodb", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
+		var (
+			conf mongodbConfig
+			err  error
+		)
+		if err = extra.Construct(&conf); err != nil {
+			return nil, err
+		}
 
-	m.database, m.collectionMatch, err = extra.compileNamespace()
-	if err != nil {
-		return m, err
-	}
+		if conf.URI == "" || conf.Namespace == "" {
+			return nil, fmt.Errorf("both uri and namespace required, but missing ")
+		}
 
+		if conf.Debug {
+			fmt.Printf("Mongo Config %+v\n", conf)
+		}
+
+		m := &Mongodb{
+			restartable:      true,            // assume for that we're able to restart the process
+			oplogTimeout:     5 * time.Second, // timeout the oplog iterator
+			pipe:             p,
+			uri:              conf.URI,
+			tail:             conf.Tail,
+			debug:            conf.Debug,
+			path:             path,
+			opsBuffer:        make(map[string][]interface{}),
+			bulkWriteChannel: make(chan *SyncDoc),
+			bulkQuitChannel:  make(chan chan bool),
+			bulk:             conf.Bulk,
+			conf:             conf,
+		}
+		// opsBuffer:        make([]*SyncDoc, 0, MONGO_BUFFER_LEN),
+
+		m.database, m.collectionMatch, err = extra.CompileNamespace()
+		if err != nil {
+			return m, err
+		}
+
+		if conf.Timeout == "" {
+			m.sessionTimeout = time.Duration(10) * time.Second
+		} else {
+			timeout, err := time.ParseDuration(conf.Timeout)
+			if err != nil {
+				return m, fmt.Errorf("unable to parse timeout (%s), %s\n", conf.Timeout, err.Error())
+			}
+			m.sessionTimeout = timeout
+		}
+
+		return m, nil
+	})
+}
+
+func (m *Mongodb) Connect() error {
 	dialInfo, err := mgo.ParseURL(m.uri)
 	if err != nil {
-		return m, fmt.Errorf("unable to parse uri (%s), %s\n", m.uri, err.Error())
+		return fmt.Errorf("unable to parse uri (%s), %s\n", m.uri, err.Error())
 	}
 
-	if conf.Ssl != nil {
+	if m.conf.Ssl != nil {
 		tlsConfig := &tls.Config{}
-		if len(conf.Ssl.CaCerts) > 0 {
+		if len(m.conf.Ssl.CaCerts) > 0 {
 			roots := x509.NewCertPool()
-			for _, caCert := range conf.Ssl.CaCerts {
+			for _, caCert := range m.conf.Ssl.CaCerts {
 				ok := roots.AppendCertsFromPEM([]byte(caCert))
 				if !ok {
-					return m, fmt.Errorf("failed to parse root certificate")
+					return fmt.Errorf("failed to parse root certificate")
 				}
 			}
 			tlsConfig.RootCAs = roots
@@ -123,33 +160,24 @@ func NewMongodb(p *pipe.Pipe, path string, extra Config) (StopStartListener, err
 		}
 	}
 
-	if conf.Timeout == "" {
-		dialInfo.Timeout = time.Duration(10) * time.Second
-	} else {
-		timeout, err := time.ParseDuration(conf.Timeout)
-		if err != nil {
-			return m, fmt.Errorf("unable to parse timeout (%s), %s\n", conf.Timeout, err.Error())
-		}
-		dialInfo.Timeout = timeout
-	}
+	dialInfo.Timeout = m.sessionTimeout
 
 	m.mongoSession, err = mgo.DialWithInfo(dialInfo)
 	if err != nil {
-		return m, err
+		return err
 	}
 
 	// set some options on the session
-	m.mongoSession.EnsureSafe(&mgo.Safe{W: conf.Wc, FSync: conf.FSync})
+	m.mongoSession.EnsureSafe(&mgo.Safe{W: m.conf.Wc, FSync: m.conf.FSync})
 	m.mongoSession.SetBatch(1000)
 	m.mongoSession.SetPrefetch(0.5)
 
 	if m.tail {
 		if iter := m.mongoSession.DB("local").C("oplog.rs").Find(bson.M{}).Limit(1).Iter(); iter.Err() != nil {
-			return m, iter.Err()
+			return iter.Err()
 		}
 	}
-
-	return m, nil
+	return nil
 }
 
 // Start the adaptor as a source
@@ -212,14 +240,14 @@ func (m *Mongodb) Stop() error {
 func (m *Mongodb) writeMessage(msg *message.Msg) (*message.Msg, error) {
 	_, msgColl, err := msg.SplitNamespace()
 	if err != nil {
-		m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (msg namespace improperly formatted, must be database.collection, got %s)", msg.Namespace), msg.Data)
+		m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error (msg namespace improperly formatted, must be database.collection, got %s)", msg.Namespace), msg.Data)
 		return msg, nil
 	}
 
 	collection := m.mongoSession.DB(m.database).C(msgColl)
 
 	if !msg.IsMap() {
-		m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (document must be a bson document, got %T instead)", msg.Data), msg.Data)
+		m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error (document must be a bson document, got %T instead)", msg.Data), msg.Data)
 		return msg, nil
 	}
 
@@ -233,7 +261,7 @@ func (m *Mongodb) writeMessage(msg *message.Msg) (*message.Msg, error) {
 	} else if msg.Op == message.Delete {
 		err := collection.Remove(doc.Doc)
 		if err != nil {
-			m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error removing (%s)", err.Error()), msg.Data)
+			m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error removing (%s)", err.Error()), msg.Data)
 		}
 	} else {
 		err := collection.Insert(doc.Doc)
@@ -241,7 +269,7 @@ func (m *Mongodb) writeMessage(msg *message.Msg) (*message.Msg, error) {
 			err = collection.Update(bson.M{"_id": doc.Doc["_id"]}, doc.Doc)
 		}
 		if err != nil {
-			m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), msg.Data)
+			m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), msg.Data)
 		}
 	}
 
@@ -255,7 +283,7 @@ func (m *Mongodb) bulkWriter() {
 		case doc := <-m.bulkWriteChannel:
 			sz, err := docSize(doc.Doc)
 			if err != nil {
-				m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), doc)
+				m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), doc)
 				break
 			}
 
@@ -297,17 +325,17 @@ func (m *Mongodb) writeBuffer() {
 					if mgo.IsDup(e) {
 						doc, ok := op.(map[string]interface{})
 						if !ok {
-							m.pipe.Err <- NewError(ERROR, m.path, "mongodb error (Cannot cast document to bson)", op)
+							m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, "mongodb error (Cannot cast document to bson)", op)
 						}
 
 						e = collection.Update(bson.M{"_id": doc["_id"]}, doc)
 					}
 					if e != nil {
-						m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (%s)", e.Error()), op)
+						m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error (%s)", e.Error()), op)
 					}
 				}
 			} else {
-				m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), docs[0])
+				m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("mongodb error (%s)", err.Error()), docs[0])
 			}
 		}
 
@@ -404,11 +432,11 @@ func (m *Mongodb) tailData() (err error) {
 				case "u":
 					doc, err = m.getOriginalDoc(result.O2, coll)
 					if err != nil { // errors aren't fatal here, but we need to send it down the pipe
-						m.pipe.Err <- NewError(ERROR, m.path, fmt.Sprintf("Mongodb error (%s)", err.Error()), nil)
+						m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, fmt.Sprintf("Mongodb error (%s)", err.Error()), nil)
 						continue
 					}
 				default:
-					m.pipe.Err <- NewError(ERROR, m.path, "Mongodb error (unknown op type)", nil)
+					m.pipe.Err <- adaptor.NewError(adaptor.ERROR, m.path, "Mongodb error (unknown op type)", nil)
 					continue
 				}
 
@@ -430,7 +458,7 @@ func (m *Mongodb) tailData() (err error) {
 			continue
 		}
 		if iter.Err() != nil {
-			return NewError(CRITICAL, m.path, fmt.Sprintf("Mongodb error (error reading collection %s)", iter.Err()), nil)
+			return adaptor.NewError(adaptor.CRITICAL, m.path, fmt.Sprintf("Mongodb error (error reading collection %s)", iter.Err()), nil)
 		}
 
 		// query will change,
@@ -489,12 +517,12 @@ func (o *oplogDoc) validOp() bool {
 	return o.Op == "i" || o.Op == "d" || o.Op == "u"
 }
 
-// MongodbConfig provides configuration options for a mongodb adaptor
+// mongodbConfig provides configuration options for a mongodb adaptor
 // the notable difference between this and dbConfig is the presence of the Tail option
-type MongodbConfig struct {
+type mongodbConfig struct {
 	URI       string     `json:"uri" doc:"the uri to connect to, in the form mongodb://user:password@host.com:27017/auth_database"`
 	Namespace string     `json:"namespace" doc:"mongo namespace to read/write"`
-	Ssl       *SslConfig `json:"ssl,omitempty" doc:"ssl options for connection"`
+	Ssl       *sslConfig `json:"ssl,omitempty" doc:"ssl options for connection"`
 	Timeout   string     `json:timeout" doc:"timeout for establishing connection, format must be parsable by time.ParseDuration and defaults to 10s"`
 	Debug     bool       `json:"debug" doc:"display debug information"`
 	Tail      bool       `json:"tail" doc:"if tail is true, then the mongodb source will tail the oplog after copying the namespace"`
@@ -503,7 +531,7 @@ type MongodbConfig struct {
 	Bulk      bool       `json:"bulk" doc:"use a buffer to bulk insert documents"`
 }
 
-type SslConfig struct {
+type sslConfig struct {
 	CaCerts []string `json:"cacerts,omitempty" doc:"array of root CAs to use in order to verify the server certificates"`
 }
 

--- a/pkg/adaptor/registry.go
+++ b/pkg/adaptor/registry.go
@@ -1,59 +1,14 @@
 package adaptor
 
-import (
-	"fmt"
-	"reflect"
+import "github.com/compose/transporter/pkg/pipe"
 
-	"github.com/compose/transporter/pkg/pipe"
-)
+// Creator defines the init structure for an adaptor
+type Creator func(*pipe.Pipe, string, Config) (StopStartListener, error)
 
-var (
-	// Adaptors is a registry of adaptor types, constructors and configs
-	Adaptors = make(Registry)
-)
+// Adaptors stores a map of adaptors by name
+var Adaptors = map[string]Creator{}
 
-func init() {
-	Register("mongo", "a mongodb adaptor that functions as both a source and a sink", NewMongodb, MongodbConfig{})
-	Register("file", "an adaptor that reads / writes files", NewFile, FileConfig{})
-	Register("elasticsearch", "an elasticsearch sink adaptor", NewElasticsearch, dbConfig{})
-	// Register("influx", "an InfluxDB sink adaptor", NewInfluxdb, dbConfig{})
-	Register("transformer", "an adaptor that transforms documents using a javascript function", NewTransformer, TransformerConfig{})
-	Register("rethinkdb", "a rethinkdb sink adaptor", NewRethinkdb, rethinkDbConfig{})
-}
-
-// Register registers an adaptor (database adaptor) for use with Transporter
-// The second argument, fn, is a constructor that returns an instance of the
-// given adaptor, config is an instance of the adaptor's config struct
-func Register(name, desc string, fn func(*pipe.Pipe, string, Config) (StopStartListener, error), config interface{}) {
-	Adaptors[name] = RegistryEntry{
-		Name:        name,
-		Description: desc,
-		Constructor: fn,
-		Config:      config,
-	}
-}
-
-// Registry maps the adaptor's name to the RegistryEntry
-type Registry map[string]RegistryEntry
-
-// RegistryEntry stores the adaptor constructor and configuration struct
-type RegistryEntry struct {
-	Name        string
-	Description string
-	Constructor func(*pipe.Pipe, string, Config) (StopStartListener, error)
-	Config      interface{}
-}
-
-// About inspects the  RegistryEntry's Config object, and uses
-// each field's tags as a docstring
-func (r *RegistryEntry) About() string {
-	doc := fmt.Sprintf("%s %s\n\n", r.Name, r.Description)
-	t := reflect.TypeOf(r.Config)
-	doc += fmt.Sprintf("%-15s %-10s %s\n", "name", "type", "description")
-	for i := 0; i < t.NumField(); i++ {
-		f := t.Field(i)
-		doc += fmt.Sprintf("%-15s %-10s %s\n", f.Tag.Get("json"), f.Type, f.Tag.Get("doc"))
-	}
-
-	return doc
+// Add should be called in init func of adaptor
+func Add(name string, creator Creator) {
+	Adaptors[name] = creator
 }

--- a/pkg/adaptor/rethinkdb/rethinkdb.go
+++ b/pkg/adaptor/rethinkdb/rethinkdb.go
@@ -56,7 +56,7 @@ func (r *Rethinkdb) SampleConfig() string {
 func init() {
 	adaptor.Add("rethinkdb", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
 		var (
-			conf rethinkDbConfig
+			conf Config
 			err  error
 		)
 		if err = extra.Construct(&conf); err != nil {
@@ -119,8 +119,8 @@ func (r *Rethinkdb) Connect() error {
 	return nil
 }
 
-// rethinkDbConfig provides custom configuration options for the RethinkDB adapter
-type rethinkDbConfig struct {
+// Config provides custom configuration options for the RethinkDB adapter
+type Config struct {
 	URI       string `json:"uri" doc:"the uri to connect to, in the form rethink://user:password@host.example:28015/database"`
 	Namespace string `json:"namespace" doc:"rethink namespace to read/write"`
 	Debug     bool   `json:"debug" doc:"if true, verbose debugging information is displayed"`

--- a/pkg/adaptor/transformer/transformer.go
+++ b/pkg/adaptor/transformer/transformer.go
@@ -49,7 +49,7 @@ func (t *Transformer) SampleConfig() string {
 func init() {
 	adaptor.Add("transformer", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
 		var (
-			conf transformerConfig
+			conf Config
 			err  error
 		)
 		if err = extra.Construct(&conf); err != nil {
@@ -243,8 +243,8 @@ func (t *Transformer) transformerError(lvl adaptor.ErrorLevel, err error, msg *m
 	return adaptor.NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", err.Error()), data)
 }
 
-// transformerConfig holds config options for a transformer adaptor
-type transformerConfig struct {
+// Config holds config options for a transformer adaptor
+type Config struct {
 	// file containing transformer javascript
 	// must define a module.exports = function(doc) { .....; return doc }
 	Filename  string `json:"filename" doc:"the filename containing the javascript transform fn"`

--- a/pkg/adaptor/transformer/transformer.go
+++ b/pkg/adaptor/transformer/transformer.go
@@ -1,4 +1,4 @@
-package adaptor
+package transformer
 
 import (
 	"fmt"
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/compose/mejson"
+	"github.com/compose/transporter/pkg/adaptor"
 	"github.com/compose/transporter/pkg/message"
 	"github.com/compose/transporter/pkg/pipe"
 	"github.com/robertkrimen/otto"
@@ -17,7 +18,8 @@ import (
 // function and then emits it.  The javascript transformation function is supplied as a seperate file on disk,
 // and is called by calling the defined module.exports function
 type Transformer struct {
-	fn string
+	fn       string
+	filename string
 
 	pipe *pipe.Pipe
 	path string
@@ -28,39 +30,59 @@ type Transformer struct {
 	vm     *otto.Otto
 }
 
-// NewTransformer creates a new transformer object
-func NewTransformer(pipe *pipe.Pipe, path string, extra Config) (StopStartListener, error) {
-	var (
-		conf TransformerConfig
-		err  error
-	)
-	if err = extra.Construct(&conf); err != nil {
-		return nil, err
+// Description for transformer adaptor
+func (t *Transformer) Description() string {
+	return "an adaptor that transforms documents using a javascript function"
+}
+
+var sampleConfig = `
+- logtransformer:
+    filename: test/transformers/passthrough_and_log.js
+    type: transformer
+`
+
+// SampleConfig for transformer adaptor
+func (t *Transformer) SampleConfig() string {
+	return sampleConfig
+}
+
+func init() {
+	adaptor.Add("transformer", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
+		var (
+			conf transformerConfig
+			err  error
+		)
+		if err = extra.Construct(&conf); err != nil {
+			return nil, err
+		}
+
+		t := &Transformer{pipe: p, path: path, filename: conf.Filename}
+
+		_, t.ns, err = extra.CompileNamespace()
+		if err != nil {
+			return t, adaptor.NewError(adaptor.CRITICAL, path, fmt.Sprintf("can't split transformer namespace (%s)", err.Error()), nil)
+		}
+
+		return t, nil
+	})
+}
+
+func (t *Transformer) Connect() error {
+	if t.filename == "" {
+		return fmt.Errorf("no filename specified")
 	}
 
-	t := &Transformer{pipe: pipe, path: path}
-
-	if conf.Filename == "" {
-		return t, fmt.Errorf("no filename specified")
-	}
-
-	_, t.ns, err = extra.compileNamespace()
+	ba, err := ioutil.ReadFile(t.filename)
 	if err != nil {
-		return t, NewError(CRITICAL, path, fmt.Sprintf("can't split transformer namespace (%s)", err.Error()), nil)
-	}
-
-	ba, err := ioutil.ReadFile(conf.Filename)
-	if err != nil {
-		return t, err
+		return err
 	}
 
 	t.fn = string(ba)
 
 	if err = t.initEnvironment(); err != nil {
-		return t, err
+		return err
 	}
-
-	return t, nil
+	return nil
 }
 
 // Listen starts the transformer's listener, reads each message from the incoming channel
@@ -76,18 +98,18 @@ func (t *Transformer) initEnvironment() (err error) {
 
 	// set up the vm environment, make `module = {}`
 	if _, err = t.vm.Run(`module = {}`); err != nil {
-		return t.transformerError(CRITICAL, err, nil)
+		return t.transformerError(adaptor.CRITICAL, err, nil)
 	}
 
 	// compile our script
 	if t.script, err = t.vm.Compile("", t.fn); err != nil {
-		return t.transformerError(CRITICAL, err, nil)
+		return t.transformerError(adaptor.CRITICAL, err, nil)
 	}
 
 	// run the script, ignore the output
 	_, err = t.vm.Run(t.script)
 	if err != nil {
-		return t.transformerError(CRITICAL, err, nil)
+		return t.transformerError(adaptor.CRITICAL, err, nil)
 	}
 	return
 }
@@ -127,14 +149,14 @@ func (t *Transformer) transformOne(msg *message.Msg) (*message.Msg, error) {
 	}
 	if msg.IsMap() {
 		if doc, err = mejson.Marshal(msg.Data); err != nil {
-			t.pipe.Err <- t.transformerError(ERROR, err, msg)
+			t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 			return msg, nil
 		}
 		currMsg["data"] = doc
 	}
 
 	if value, err = t.vm.ToValue(currMsg); err != nil {
-		t.pipe.Err <- t.transformerError(ERROR, err, msg)
+		t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 		return msg, nil
 	}
 
@@ -142,19 +164,19 @@ func (t *Transformer) transformOne(msg *message.Msg) (*message.Msg, error) {
 	// lets run our transformer on the document
 	beforeVM := time.Now().Nanosecond()
 	if outDoc, err = t.vm.Call(`module.exports`, nil, value); err != nil {
-		t.pipe.Err <- t.transformerError(ERROR, err, msg)
+		t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 		return msg, nil
 	}
 
 	if result, err = outDoc.Export(); err != nil {
-		t.pipe.Err <- t.transformerError(ERROR, err, msg)
+		t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 		return msg, nil
 	}
 
 	afterVM := time.Now().Nanosecond()
 
 	if err = t.toMsg(result, msg); err != nil {
-		t.pipe.Err <- t.transformerError(ERROR, err, msg)
+		t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 		return msg, err
 	}
 
@@ -178,19 +200,19 @@ func (t *Transformer) toMsg(incoming interface{}, msg *message.Msg) error {
 		case otto.Value:
 			exported, err := data.Export()
 			if err != nil {
-				t.pipe.Err <- t.transformerError(ERROR, err, msg)
+				t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 				return nil
 			}
 			d, err := mejson.Unmarshal(exported.(map[string]interface{}))
 			if err != nil {
-				t.pipe.Err <- t.transformerError(ERROR, err, msg)
+				t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 				return nil
 			}
 			msg.Data = map[string]interface{}(d)
 		case map[string]interface{}:
 			d, err := mejson.Unmarshal(data)
 			if err != nil {
-				t.pipe.Err <- t.transformerError(ERROR, err, msg)
+				t.pipe.Err <- t.transformerError(adaptor.ERROR, err, msg)
 				return nil
 			}
 			msg.Data = map[string]interface{}(d)
@@ -209,20 +231,20 @@ func (t *Transformer) toMsg(incoming interface{}, msg *message.Msg) error {
 	return nil
 }
 
-func (t *Transformer) transformerError(lvl ErrorLevel, err error, msg *message.Msg) error {
+func (t *Transformer) transformerError(lvl adaptor.ErrorLevel, err error, msg *message.Msg) error {
 	var data interface{}
 	if msg != nil {
 		data = msg.Data
 	}
 
 	if e, ok := err.(*otto.Error); ok {
-		return NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", e.String()), data)
+		return adaptor.NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", e.String()), data)
 	}
-	return NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", err.Error()), data)
+	return adaptor.NewError(lvl, t.path, fmt.Sprintf("transformer error (%s)", err.Error()), data)
 }
 
-// TransformerConfig holds config options for a transformer adaptor
-type TransformerConfig struct {
+// transformerConfig holds config options for a transformer adaptor
+type transformerConfig struct {
 	// file containing transformer javascript
 	// must define a module.exports = function(doc) { .....; return doc }
 	Filename  string `json:"filename" doc:"the filename containing the javascript transform fn"`

--- a/pkg/adaptor/transformer/transformer_test.go
+++ b/pkg/adaptor/transformer/transformer_test.go
@@ -1,4 +1,4 @@
-package adaptor
+package transformer
 
 import (
 	"reflect"

--- a/pkg/transporter/pipeline_integration_test.go
+++ b/pkg/transporter/pipeline_integration_test.go
@@ -9,12 +9,13 @@ import (
 	"time"
 
 	"github.com/compose/transporter/pkg/adaptor"
+	_ "github.com/compose/transporter/pkg/adaptor/all"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
 var (
-	mongoUri = "mongodb://localhost/test"
+	mongoUri = "mongodb://127.0.0.1:27017/test"
 )
 
 // set up some local files
@@ -104,8 +105,8 @@ func TestMongoToMongo(t *testing.T) {
 	)
 
 	// create the source node and attach our sink
-	outNode := NewNode("localOutmongo", "mongo", adaptor.Config{"uri": mongoUri, "namespace": outNs}).
-		Add(NewNode("localInmongo", "mongo", adaptor.Config{"uri": mongoUri, "namespace": inNs}))
+	outNode := NewNode("localOutmongo", "mongodb", adaptor.Config{"uri": mongoUri, "namespace": outNs}).
+		Add(NewNode("localInmongo", "mongodb", adaptor.Config{"uri": mongoUri, "namespace": inNs}))
 
 	// create the pipeline
 	p, err := NewDefaultPipeline(outNode, "", "", "", 100*time.Millisecond)

--- a/pkg/transporter/pipeline_test.go
+++ b/pkg/transporter/pipeline_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/compose/transporter/pkg/adaptor"
+	_ "github.com/compose/transporter/pkg/adaptor/file"
 	"github.com/compose/transporter/pkg/pipe"
 )
 
@@ -19,12 +20,26 @@ type Testadaptor struct {
 	value string
 }
 
-func NewTestadaptor(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
-	val, ok := extra["value"]
-	if !ok {
-		return nil, errors.New("this is an error")
-	}
-	return &Testadaptor{value: val.(string)}, nil
+func init() {
+	adaptor.Add("source", func(p *pipe.Pipe, path string, extra adaptor.Config) (adaptor.StopStartListener, error) {
+		val, ok := extra["value"]
+		if !ok {
+			return nil, errors.New("this is an error")
+		}
+		return &Testadaptor{value: val.(string)}, nil
+	})
+}
+
+func (s *Testadaptor) Description() string {
+	return "description"
+}
+
+func (s *Testadaptor) SampleConfig() string {
+	return ""
+}
+
+func (s *Testadaptor) Connect() error {
+	return nil
 }
 
 func (s *Testadaptor) Stop() error {
@@ -40,8 +55,6 @@ func (s *Testadaptor) Listen() error {
 }
 
 func TestPipelineString(t *testing.T) {
-	adaptor.Register("source", "description", NewTestadaptor, struct{}{})
-
 	data := []struct {
 		in           *Node
 		terminalNode *Node


### PR DESCRIPTION
The following changes replace the need for special `NewADAPTOR` functions and instead uses the standard `init` func for adaptor registrion. All adaptors are imported in `all.go` using the blank identifier, `_`. 

In order to continue supporting the `about` command, `Description`, and `Connect` functions were added to the adaptor interface. This resulted in moving any connection checks from the `NewADAPTOR` (i.e. `init`) function to `Connect` users can run `about` without having to worry about the adaptor source being available.

An additional function was added to the adaptor interface, `SampleConfig`, for a future command being worked on but can easily be removed if needed.