### PR TITLE
defer bulk channel init for mongo node reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v0.1.2 [UNRELEASED]
 
 ### Bugfixes
+- [#211](https://github.com/compose/transporter/pull/211): defer bulk channel init for mongo node reuse
 - [#213](https://github.com/compose/transporter/pull/213): track mongodb \_id field so we can attempt to reissue queries
 
 

--- a/pkg/adaptor/mongodb/mongodb.go
+++ b/pkg/adaptor/mongodb/mongodb.go
@@ -104,18 +104,16 @@ func init() {
 		}
 
 		m := &MongoDB{
-			restartable:      true,            // assume for that we're able to restart the process
-			oplogTimeout:     5 * time.Second, // timeout the oplog iterator
-			pipe:             p,
-			uri:              conf.URI,
-			tail:             conf.Tail,
-			debug:            conf.Debug,
-			path:             path,
-			opsBuffer:        make(map[string][]message.Msg),
-			bulkWriteChannel: make(chan syncDoc),
-			bulkQuitChannel:  make(chan chan bool),
-			bulk:             conf.Bulk,
-			conf:             conf,
+			restartable:  true,            // assume for that we're able to restart the process
+			oplogTimeout: 5 * time.Second, // timeout the oplog iterator
+			pipe:         p,
+			uri:          conf.URI,
+			tail:         conf.Tail,
+			debug:        conf.Debug,
+			path:         path,
+			opsBuffer:    make(map[string][]message.Msg),
+			bulk:         conf.Bulk,
+			conf:         conf,
 		}
 		// opsBuffer:        make([]*SyncDoc, 0, MONGO_BUFFER_LEN),
 
@@ -218,6 +216,8 @@ func (m *MongoDB) Listen() (err error) {
 	}()
 
 	if m.bulk {
+		m.bulkWriteChannel = make(chan syncDoc)
+		m.bulkQuitChannel = make(chan chan bool)
 		go m.bulkWriter()
 	}
 	return m.pipe.Listen(m.writeMessage, m.collectionMatch)
@@ -228,7 +228,7 @@ func (m *MongoDB) Stop() error {
 	m.pipe.Stop()
 
 	// if we're bulk writing, ask our writer to exit here
-	if m.bulk {
+	if m.bulkWriteChannel != nil {
 		q := make(chan bool)
 		m.bulkQuitChannel <- q
 		<-q
@@ -390,6 +390,7 @@ func (m *MongoDB) catData() error {
 				continue
 			}
 			errSleep = time.Second
+			iter.Close()
 			sess.Close()
 			break
 		}


### PR DESCRIPTION
- [ ] CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)

When a mongodb adaptor is defined in the `config.yaml` with `bulk=true` and is used for the `Source` and `Sink` in the `application.js`, transporter will never shutdown properly.

The following change adds a new field to the adaptor and sets it when the `Listen` func is called and checked with `Stop` is called.

fixes #152 