### PR TITLE
track mongodb _id field so we can attempt to reissue queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.1.2 [UNRELEASED]
+
+### Bugfixes
+- [#213](https://github.com/compose/transporter/pull/213): track mongodb \_id field so we can attempt to reissue queries
+
+
 ## v0.1.1 [2015-08-27]
 
 This release contains the first step to getting savable state into adaptors for the ability to resume.

--- a/pkg/adaptor/mongodb/mongodb_test.go
+++ b/pkg/adaptor/mongodb/mongodb_test.go
@@ -1,0 +1,51 @@
+package mongodb
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+var sorttests = []struct {
+	in       interface{}
+	sortable bool
+}{
+	{"IamAstring", true},
+	{bson.NewObjectId(), true},
+	{time.Now(), true},
+	{int64(1000), true},
+	{float64(100.9), true},
+	{100.5, true},
+	{1000, false},
+	{false, false},
+}
+
+func TestSortable(t *testing.T) {
+	for _, st := range sorttests {
+		out := sortable(st.in)
+		if out != st.sortable {
+			t.Errorf("unexpected result for %+v, expected %+v, got %+v", st.in, st.sortable, out)
+		}
+	}
+}
+
+var rawtests = []struct {
+	in  string
+	out interface{}
+}{
+	{"IamAstring", "IamAstring"},
+	{"584ed2fe56463f2a877b352b", bson.ObjectIdHex("584ed2fe56463f2a877b352b")},
+	{"100.5", 100.5},
+	{"1000", 1000},
+}
+
+func TestRawDataFromString(t *testing.T) {
+	for _, rt := range rawtests {
+		result := rawDataFromString(rt.in)
+		if result != rt.out {
+			t.Errorf("unexpected result for %+v, expected %+v, got %+v", rt.in, rt.out, result)
+		}
+	}
+
+}

--- a/pkg/message/adaptor/mongodb/mongodb.go
+++ b/pkg/message/adaptor/mongodb/mongodb.go
@@ -44,7 +44,9 @@ func (r Adaptor) Insert(m message.Msg) error {
 	if err != nil {
 		return err
 	}
-	return r.sess.DB(db).C(coll).Insert(m.Data())
+	sess := r.sess.Copy()
+	defer sess.Close()
+	return sess.DB(db).C(coll).Insert(m.Data())
 }
 
 func (r Adaptor) BulkInsert(db string, coll string, m ...message.Msg) error {


### PR DESCRIPTION
- [x] CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)

This change brings back the ability to re-issue a query after an err has been encountered while iterating a collection. For now, we will only attempt to perform the retry if the `_id` field is properly indexed is one of `bson.ObjectId, string, float64, time.Time`.