### PR TITLE
fix flush error when total bulk message > 16MB

### DIFF
--- a/pkg/adaptor/mongodb/bulk.go
+++ b/pkg/adaptor/mongodb/bulk.go
@@ -76,11 +76,11 @@ func (b *Bulk) Write(msg message.Msg) func(client.Session) error {
 		case ops.Update:
 			bOp.bulk.Update(bson.M{"_id": msg.Data().Get("_id")}, msg.Data())
 		}
+		bOp.opCounter++
 		if bOp.opCounter%20 == 0 {
 			log.With("opCounter", bOp.opCounter).Debugln("calculating avg obj size")
 			bOp.calculateAvgObjSize(msg.Data())
 		}
-		bOp.opCounter++
 		bOp.bsonOpSize = int(bOp.avgOpSize) * bOp.opCounter
 		bOp.Unlock()
 		var err error

--- a/pkg/adaptor/mongodb/bulk.go
+++ b/pkg/adaptor/mongodb/bulk.go
@@ -122,7 +122,7 @@ func (b *Bulk) flushAll() error {
 func (b *Bulk) flush(c string, bOp *bulkOperation) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	log.With("collection", c).With("opCounter", bOp.opCounter).With("bsonOpSize", bOp.bsonOpSize).Debugln("flushing bulk messages")
+	log.With("collection", c).With("opCounter", bOp.opCounter).With("bsonOpSize", bOp.bsonOpSize).Infoln("flushing bulk messages")
 	result, err := bOp.bulk.Run()
 	if err != nil {
 		log.With("collection", c).Errorf("flush error, %s\n", err)
@@ -132,7 +132,7 @@ func (b *Bulk) flush(c string, bOp *bulkOperation) error {
 	log.With("collection", c).
 		With("modified", result.Modified).
 		With("match", result.Matched).
-		Debugln("flush complete")
+		Infoln("flush complete")
 	delete(b.bulkMap, c)
 	return nil
 }

--- a/pkg/adaptor/mongodb/bulk.go
+++ b/pkg/adaptor/mongodb/bulk.go
@@ -98,13 +98,11 @@ func (bOp *bulkOperation) calculateAvgObjSize(d data.Data) {
 		log.Infof("unable to marshal doc to BSON, not adding to average", err)
 		return
 	}
-	bOp.Lock()
 	bOp.avgOpCount++
 	// add the 4 bytes for the MsgHeader
 	// https://docs.mongodb.com/manual/reference/mongodb-wire-protocol/#standard-message-header
 	bOp.avgTotal += (len(bs) + 4)
 	bOp.avgOpSize = float64(bOp.avgTotal / bOp.avgOpCount)
-	bOp.Unlock()
 	log.With("avgOpCount", bOp.avgOpCount).With("avgTotal", bOp.avgTotal).With("avgObSize", bOp.avgOpSize).Debugln("bulk stats")
 }
 

--- a/pkg/adaptor/mongodb/bulk_test.go
+++ b/pkg/adaptor/mongodb/bulk_test.go
@@ -140,7 +140,10 @@ func TestBulkMulitpleCollections(t *testing.T) {
 }
 
 func TestBulkSize(t *testing.T) {
-	b := &Bulk{bulkMap: make(map[string]*bulkOperation)}
+	b := &Bulk{
+		bulkMap: make(map[string]*bulkOperation),
+		RWMutex: &sync.RWMutex{},
+	}
 	ns := fmt.Sprintf("%s.%s", bulkTestData.DB, "size")
 	var bsonSize int
 	for i := 0; i < (maxObjSize - 1); i++ {

--- a/pkg/adaptor/mongodb/reader.go
+++ b/pkg/adaptor/mongodb/reader.go
@@ -107,10 +107,10 @@ func (r *Reader) iterateCollection(mgoSession *mgo.Session, in <-chan string, do
 					iter := r.catQuery(c, lastID, s).Iter()
 					var result bson.M
 					for iter.Next(&result) {
-						out <- resultDoc{result, c}
 						if id, ok := result["_id"]; ok {
 							lastID = id
 						}
+						out <- resultDoc{result, c}
 						result = bson.M{}
 					}
 					if err := iter.Err(); err != nil {

--- a/pkg/adaptor/mongodb/writer.go
+++ b/pkg/adaptor/mongodb/writer.go
@@ -19,9 +19,9 @@ type Writer struct {
 func newWriter() *Writer {
 	w := &Writer{}
 	w.writeMap = map[ops.Op]func(message.Msg, *mgo.Collection) error{
-		ops.Insert: insert,
-		ops.Update: update,
-		ops.Delete: delete,
+		ops.Insert: insertMsg,
+		ops.Update: updateMsg,
+		ops.Delete: deleteMsg,
 	}
 	return w
 }
@@ -42,18 +42,18 @@ func msgCollection(msg message.Msg, s client.Session) *mgo.Collection {
 	return s.(*Session).mgoSession.DB(db).C(coll)
 }
 
-func insert(msg message.Msg, c *mgo.Collection) error {
+func insertMsg(msg message.Msg, c *mgo.Collection) error {
 	err := c.Insert(msg.Data())
 	if err != nil && mgo.IsDup(err) {
-		return update(msg, c)
+		return updateMsg(msg, c)
 	}
 	return err
 }
 
-func update(msg message.Msg, c *mgo.Collection) error {
+func updateMsg(msg message.Msg, c *mgo.Collection) error {
 	return c.Update(bson.M{"_id": msg.Data().Get("_id")}, msg.Data())
 }
 
-func delete(msg message.Msg, c *mgo.Collection) error {
+func deleteMsg(msg message.Msg, c *mgo.Collection) error {
 	return c.RemoveId(msg.Data().Get("_id"))
 }


### PR DESCRIPTION
By only tracking the total number of operations, we run the risk of hitting the total document size limit of 16MB for an operation. The following change tracks a total Bulk Message Size by calculating an average doc size every 20 docs. In order to have a roughly accurate estimate of the doc size, the average needs to be computed on a collection by collection basis so all counters were moved to the `bulkOperation` struct. This allows flushes to happen at the collection level instead of the total message level.