### PR TITLE
return a nil message to get skipped in the pipeline

### DIFF
--- a/pkg/adaptor/transformer/transformer.go
+++ b/pkg/adaptor/transformer/transformer.go
@@ -6,13 +6,13 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/compose/mejson"
 	"github.com/compose/transporter/pkg/adaptor"
 	"github.com/compose/transporter/pkg/message"
 	"github.com/compose/transporter/pkg/message/adaptor/transformer"
 	"github.com/compose/transporter/pkg/message/data"
 	"github.com/compose/transporter/pkg/message/ops"
 	"github.com/compose/transporter/pkg/pipe"
-	"github.com/compose/mejson"
 	"github.com/robertkrimen/otto"
 	_ "github.com/robertkrimen/otto/underscore" // enable underscore
 )
@@ -236,7 +236,7 @@ func (t *Transformer) toMsg(origMsg message.Msg, incoming interface{}) (message.
 		}
 	case bool: // skip this doc if we're a bool and we're false
 		if !newMsg {
-			op = ops.Noop
+			return nil, nil
 		}
 	default: // something went wrong
 		return nil, fmt.Errorf("returned doc was not a map[string]interface{}: was %T", newMsg)

--- a/pkg/adaptor/transformer/transformer_test.go
+++ b/pkg/adaptor/transformer/transformer_test.go
@@ -102,7 +102,7 @@ func TestTransformOne(t *testing.T) {
 			"we should be able to skip a nil message",
 			"module.exports=function(doc) { return false }",
 			message.MustUseAdaptor("transformer").From(ops.Insert, "database.collection", data.Data{"id": bsonID1, "name": "nick"}),
-			message.MustUseAdaptor("transformer").From(ops.Noop, "database.collection", data.Data{"id": bsonID1, "name": "nick"}),
+			nil,
 			false,
 		},
 		{
@@ -138,6 +138,9 @@ func TestTransformOne(t *testing.T) {
 }
 
 func isEqual(m1 message.Msg, m2 message.Msg) bool {
+	if m1 == nil && m2 == nil {
+		return true
+	}
 	if m1.ID() != m2.ID() {
 		return false
 	}


### PR DESCRIPTION
rather than rely on changing the op type for a message to be skipped, setting it to `nil` will result in getting skipped [here](https://github.com/compose/transporter/blob/df11d3251a92c71cfd255a8dfb4901ba2153d673/pkg/pipe/pipe.go#L107-L109)

fixes #260 