### PR TITLE
cleanup all sessions obtained from mgo

### DIFF
--- a/pkg/adaptor/mongodb/client.go
+++ b/pkg/adaptor/mongodb/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/compose/transporter/pkg/client"
 	"github.com/compose/transporter/pkg/log"
-	"github.com/compose/transporter/pkg/message"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
@@ -96,7 +95,6 @@ type Client struct {
 	tail           bool
 
 	mgoSession *mgo.Session
-	bulkWriter chan message.Msg
 }
 
 // NewClient creates a new client to work with MongoDB.
@@ -121,7 +119,6 @@ func NewClient(options ...ClientOptionFunc) (*Client, error) {
 		safety:         DefaultSafety,
 		tlsConfig:      nil,
 		tail:           false,
-		bulkWriter:     nil,
 	}
 
 	// Run the options on it
@@ -233,7 +230,9 @@ func (c *Client) Connect() (client.Session, error) {
 
 // Close satisfies the Closer interface and handles closing the initial mgo.Session.
 func (c Client) Close() {
-	c.mgoSession.Close()
+	if c.mgoSession != nil {
+		c.mgoSession.Close()
+	}
 }
 
 func (c *Client) initConnection() error {

--- a/pkg/adaptor/mongodb/client_test.go
+++ b/pkg/adaptor/mongodb/client_test.go
@@ -356,5 +356,8 @@ func TestConnect(t *testing.T) {
 		if err != ct.expectedErr {
 			t.Fatalf("[%s] unexpected Connect error, expected %+v, got %+v\n", ct.name, ct.expectedErr, err)
 		}
+		if err != nil {
+			ct.client.Close()
+		}
 	}
 }

--- a/pkg/adaptor/mongodb/mongodb.go
+++ b/pkg/adaptor/mongodb/mongodb.go
@@ -127,7 +127,10 @@ func (m *MongoDB) SampleConfig() string {
 
 // Connect tests the mongodb connection and initializes the mongo session
 func (m *MongoDB) Connect() error {
-	_, err := m.client.Connect()
+	s, err := m.client.Connect()
+	if s, ok := s.(client.Closer); ok {
+		s.Close()
+	}
 	return err
 }
 
@@ -141,6 +144,9 @@ func (m *MongoDB) Start() (err error) {
 	s, err := m.client.Connect()
 	if err != nil {
 		return err
+	}
+	if s, ok := s.(client.Closer); ok {
+		defer s.Close()
 	}
 	readFunc := m.reader.Read(m.collectionFilter)
 	msgChan, err := readFunc(s, m.doneChannel)


### PR DESCRIPTION
we can never throw away sessions because mgo allocates a goroutine for each one and expects Close() to eventually be called

fixes #270