### PR TITLE
cleanup metrics and error routines with a done channel

### DIFF
--- a/pkg/events/emitter.go
+++ b/pkg/events/emitter.go
@@ -53,7 +53,9 @@ func (e *emitter) Start() {
 
 // Stop sends a stop signal and waits for the inflight posts to complete before exiting
 func (e *emitter) Stop() {
-	close(e.stop)
+	if e.stop != nil {
+		close(e.stop)
+	}
 	e.wg.Wait()
 	e.started = false
 }

--- a/pkg/events/emitter.go
+++ b/pkg/events/emitter.go
@@ -53,9 +53,7 @@ func (e *emitter) Start() {
 
 // Stop sends a stop signal and waits for the inflight posts to complete before exiting
 func (e *emitter) Stop() {
-	if e.stop != nil {
-		close(e.stop)
-	}
+	close(e.stop)
 	e.wg.Wait()
 	e.started = false
 }

--- a/pkg/pipe/pipe.go
+++ b/pkg/pipe/pipe.go
@@ -130,6 +130,7 @@ func (m *Pipe) Stop() {
 			c := make(chan bool)
 			m.chStop <- c
 			<-c
+			close(m.Err)
 		}
 	}
 }

--- a/pkg/transporter/pipeline.go
+++ b/pkg/transporter/pipeline.go
@@ -107,7 +107,6 @@ func (pipeline *Pipeline) Stop() {
 	pipeline.emitMetrics()
 	pipeline.source.pipe.Event <- events.NewExitEvent(time.Now().UnixNano(), pipeline.version, endpoints)
 	pipeline.emitter.Stop()
-
 }
 
 // Run the pipeline
@@ -140,13 +139,11 @@ func (pipeline *Pipeline) startErrorListener(cherr chan error) {
 				if aerr.Lvl == adaptor.ERROR || aerr.Lvl == adaptor.CRITICAL {
 					log.With("path", aerr.Path).Errorln(aerr)
 				}
-			} else {
+			} else if err != nil {
 				if pipeline.Err == nil {
 					pipeline.Err = err
 				}
-				if pipeline.Err != nil {
-					pipeline.Stop()
-				}
+				pipeline.Stop()
 			}
 		case <-pipeline.done:
 			return

--- a/pkg/transporter/pipeline.go
+++ b/pkg/transporter/pipeline.go
@@ -133,13 +133,16 @@ func (pipeline *Pipeline) Run() error {
 func (pipeline *Pipeline) startErrorListener(cherr chan error) {
 	for {
 		select {
-		case err := <-cherr:
+		case err, ok := <-cherr:
+			if !ok {
+				return
+			}
 			if aerr, ok := err.(adaptor.Error); ok {
 				pipeline.source.pipe.Event <- events.NewErrorEvent(time.Now().UnixNano(), aerr.Path, aerr.Record, aerr.Error())
 				if aerr.Lvl == adaptor.ERROR || aerr.Lvl == adaptor.CRITICAL {
 					log.With("path", aerr.Path).Errorln(aerr)
 				}
-			} else if err != nil {
+			} else {
 				if pipeline.Err == nil {
 					pipeline.Err = err
 				}

--- a/pkg/transporter/pipeline_integration_test.go
+++ b/pkg/transporter/pipeline_integration_test.go
@@ -1,6 +1,8 @@
 package transporter
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -26,7 +28,14 @@ func setupFiles(in, out string) {
 func TestFileToFile(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping FileToFile in short mode")
+
 	}
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	}))
+	defer ts.Close()
+	ts.Start()
+
 	var (
 		tempDir = os.TempDir()
 		inFile  = filepath.Join(tempDir, "in")
@@ -40,7 +49,7 @@ func TestFileToFile(t *testing.T) {
 		Add(NewNode("localfilein", "file", adaptor.Config{"uri": "file://" + inFile}))
 
 	// create the pipeline
-	p, err := NewDefaultPipeline(outNode, "", "", "", "test", 100*time.Millisecond)
+	p, err := NewDefaultPipeline(outNode, ts.URL, "", "", "test", 100*time.Millisecond)
 	if err != nil {
 		t.Errorf("can't create pipeline, got %s", err.Error())
 		t.FailNow()


### PR DESCRIPTION
addresses the remaining leaky goroutines as reported [here](https://github.com/compose/transporter/issues/265#issuecomment-281731263)

fixes #265