### PR TITLE
ignore any errors returned from calling Creator func in about cmd

### DIFF
--- a/cmd/transporter/about.go
+++ b/cmd/transporter/about.go
@@ -23,10 +23,7 @@ func runAbout(args []string) error {
 	}
 
 	for name, creator := range adaptor.Adaptors {
-		dummyAdaptor, err := creator(nil, "", adaptor.Config{"uri": "test", "namespace": "test.test"})
-		if err != nil {
-			return fmt.Errorf("unable to create adaptor '%s', %s", name, err)
-		}
+		dummyAdaptor, _ := creator(nil, "", adaptor.Config{"uri": "test", "namespace": "test.test"})
 		if d, ok := dummyAdaptor.(adaptor.Describable); ok {
 			fmt.Printf("%s - %s\n", name, d.Description())
 		} else {


### PR DESCRIPTION
because we are not actually using the created adaptor but simply needing a reference to it for the Description() call we can ignore any errors, most of the logic to create/register adaptors will be changing soon as well

fixes #284