### PR TITLE
check if resp is not nil before adding to log context

### DIFF
--- a/adaptor/elasticsearch/clients/v2/writer.go
+++ b/adaptor/elasticsearch/clients/v2/writer.go
@@ -99,12 +99,14 @@ func (w *Writer) Close() {
 }
 
 func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableRequest, resp *elastic.BulkResponse, err error) {
-	ctxLog := w.logger.
-		With("executionID", executionID).
-		With("took", fmt.Sprintf("%dms", resp.Took)).
-		With("succeeeded", len(resp.Succeeded()))
+	ctxLog := w.logger.With("executionID", executionID)
+	if resp != nil {
+		ctxLog.With("took", fmt.Sprintf("%dms", resp.Took)).
+			With("succeeeded", len(resp.Succeeded())).
+			With("failed", len(resp.Failed()))
+	}
 	if err != nil {
-		ctxLog.With("failed", len(resp.Failed())).Errorln(err)
+		ctxLog.Errorln(err)
 		return
 	}
 	ctxLog.Infoln("_bulk flush completed")

--- a/adaptor/elasticsearch/clients/v5/writer.go
+++ b/adaptor/elasticsearch/clients/v5/writer.go
@@ -99,12 +99,14 @@ func (w *Writer) Close() {
 }
 
 func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableRequest, resp *elastic.BulkResponse, err error) {
-	ctxLog := w.logger.
-		With("executionID", executionID).
-		With("took", fmt.Sprintf("%dms", resp.Took)).
-		With("succeeeded", len(resp.Succeeded()))
+	ctxLog := w.logger.With("executionID", executionID)
+	if resp != nil {
+		ctxLog.With("took", fmt.Sprintf("%dms", resp.Took)).
+			With("succeeeded", len(resp.Succeeded())).
+			With("failed", len(resp.Failed()))
+	}
 	if err != nil {
-		ctxLog.With("failed", len(resp.Failed())).Errorln(err)
+		ctxLog.Errorln(err)
 		return
 	}
 	ctxLog.Infoln("_bulk flush completed")


### PR DESCRIPTION
it's possible the resp returned from elastigo is nil so let's check that before adding to the log context.

fixes #291 