### PR TITLE
dont use channels for listing or iterating collections

### DIFF
--- a/adaptor/mongodb/adaptor_test.go
+++ b/adaptor/mongodb/adaptor_test.go
@@ -20,7 +20,7 @@ var (
 
 	dbsToTest = []*TestData{
 		bulkTestData,
-		readerTestData, filteredReaderTestData,
+		readerTestData, filteredReaderTestData, cancelledReaderTestData,
 		writerTestData,
 		tailTestData}
 )

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -111,7 +111,6 @@ func (m *Pipe) Stop() {
 
 		// we only worry about the stop channel if we're in a listening loop
 		if m.listening {
-			close(m.In)
 			if len(m.Out) > 0 {
 				close(m.Err)
 			}

--- a/pipeline/pipeline_integration_test.go
+++ b/pipeline/pipeline_integration_test.go
@@ -60,7 +60,7 @@ func TestFileToFile(t *testing.T) {
 	p.Stop()
 	time.Sleep(1 * time.Second)
 	numgorosAfter := runtime.NumGoroutine()
-	if numgorosBefore != numgorosAfter {
+	if numgorosBefore < numgorosAfter {
 		trace := make([]byte, 10240)
 		runtime.Stack(trace, true)
 		t.Errorf("leaky goroutines detected, started with %d, ended with %d\n%s", numgorosBefore, numgorosAfter, trace)


### PR DESCRIPTION
we were already processing collections 1 at a time so the use of channels was overly complex for the need. It also prevented us from being able to easily stop iterating a collection when the `done` channel was closed which resulted in the top-level `out` channel to be closed which would then cause a panic when we tried to send on a closed channel.

also discovered a bug introduced in https://github.com/compose/transporter/pull/308 where closing the pipe's `In` channel would cause a panic send on closed channel when Ctrl+C'ing a running process.

fixes #307 