### PR TITLE
prompt before overwriting pipeline.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v0.3.1 [UNRELEASED]
+## v0.3.1 [2017-03-24]
 
 ### Features
 - added `js` alias for `goja` transform function [#335](https://github.com/compose/transporter/pull/335) 
+- `init` command will now prompt user when `pipeline.js` file already exists [#336](https://github.com/compose/transporter/pull/336)
 
 ### Bugfixes
 - fixed mongodb, rabbitmq, and rethinkdb adaptors from not trying to read from a file when provided in the `ca_certs` field [#334](https://github.com/compose/transporter/pull/334)

--- a/cmd/transporter/init.go
+++ b/cmd/transporter/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/compose/transporter/adaptor"
 )
@@ -17,6 +18,15 @@ func runInit(args []string) error {
 	args = flagset.Args()
 	if len(args) != 2 {
 		return fmt.Errorf("wrong number of arguments provided, expected 2, got %d", len(args))
+	}
+	if _, err := os.Stat("pipeline.js"); err == nil {
+		fmt.Print("pipeline.js exists, overwrite? (y/n) ")
+		var overwrite string
+		fmt.Scanln(&overwrite)
+		if strings.ToLower(overwrite) != "y" {
+			fmt.Println("not overwriting pipeline.js, exiting...")
+			return nil
+		}
 	}
 	fmt.Println("Writing pipeline.js...")
 	appFileHandle, err := os.Create(defaultPipelineFile)
@@ -34,9 +44,7 @@ func runInit(args []string) error {
 			return fmt.Errorf("adaptor '%s' did not provide a sample config", name)
 		}
 	}
-	appFileHandle.WriteString(`t.Source(source).Save(sink)`)
-	appFileHandle.WriteString(`// t.Source("source", source).Save("sink", sink)`)
-	appFileHandle.WriteString(`// t.Source("source", source, "/.*/").Save("sink", sink, "/.*/")`)
+	appFileHandle.WriteString(`t.Source("source", source, "/.*/").Save("sink", sink, "/.*/")`)
 	appFileHandle.WriteString("\n")
 	return nil
 }


### PR DESCRIPTION
if pipeline.js already exists, prompt user for y/n on whether to continue; also, only write example pipeline with all arguments

fixes #320

- [x] CHANGELOG.md updated
