### PR TITLE
Mongo unwind support

### DIFF
--- a/adaptor/mongodb/README.md
+++ b/adaptor/mongodb/README.md
@@ -7,6 +7,16 @@ receiving data for inserts.
 is a query that will be used when iterating the collection. The commented out example below would only 
 include documents where the `i` field had a value greater than `10`.
 
+`unwind` is a JSON string where the top level key is the collection name and its value a key-value pair that 
+lets specify an array field from the input documents to output a document for each element. Key name sould be `fieldPath`.
+
+Example: 
+```
+JSON.stringify({
+  fooCollection: { fieldPath: "$barArrayField" } 
+})
+```
+
 ***NOTE*** You may want to check your collections to ensure the proper index(es) are in place or performance may suffer.
 
 ### Configuration:
@@ -20,6 +30,11 @@ m = mongodb({
   // "wc": 1,
   // "fsync": false,
   // "bulk": false,
-  // "collection_filters": "{\"foo\": {\"i\": {\"$gt\": 10}}}"
+  // "collection_filters": "{\"foo\": {\"i\": {\"$gt\": 10}}}",
+  // "unwind": JSON.stringify({
+  //    fooCollection: {
+  //        fieldPath: "$barArrayField"
+  //    }
+  // })
 })
 ```

--- a/adaptor/mongodb/reader.go
+++ b/adaptor/mongodb/reader.go
@@ -21,20 +21,26 @@ var (
 
 	// DefaultCollectionFilter is an empty map of empty maps
 	DefaultCollectionFilter = map[string]CollectionFilter{}
+	// DefaultUnwind is an empty map of empty byte (raw json array)
+	DefaultUnwind = map[string]Unwind{}
 )
 
 // CollectionFilter is just a typed map of strings of map[string]interface{}
 type CollectionFilter map[string]interface{}
 
+// Unwind is just a typed map of strings of map[string]interface{}
+type Unwind map[string]interface{}
+
 // Reader implements the behavior defined by client.Reader for interfacing with MongoDB.
 type Reader struct {
 	tail              bool
 	collectionFilters map[string]CollectionFilter
+	unwind            map[string]Unwind
 	oplogTimeout      time.Duration
 }
 
-func newReader(tail bool, filters map[string]CollectionFilter) client.Reader {
-	return &Reader{tail, filters, 5 * time.Second}
+func newReader(tail bool, filters map[string]CollectionFilter, unwind map[string]Unwind) client.Reader {
+	return &Reader{tail, filters, unwind, 5 * time.Second}
 }
 
 type resultDoc struct {
@@ -169,7 +175,7 @@ func (r *Reader) iterate(s *mgo.Session, c string) <-chan message.Msg {
 	return msgChan
 }
 
-func (r *Reader) catQuery(c string, lastID interface{}, mgoSession *mgo.Session) *mgo.Query {
+func (r *Reader) catQuery(c string, lastID interface{}, mgoSession *mgo.Session) *mgo.Pipe {
 	query := bson.M{}
 	if f, ok := r.collectionFilters[c]; ok {
 		query = bson.M(f)
@@ -177,7 +183,20 @@ func (r *Reader) catQuery(c string, lastID interface{}, mgoSession *mgo.Session)
 	if lastID != nil {
 		query["_id"] = bson.M{"$gt": lastID}
 	}
-	return mgoSession.DB("").C(c).Find(query).Sort("_id")
+	if u, ok := r.unwind[c]; ok {
+		if fieldPath, ok := u["fieldPath"]; ok {
+			pipeline := []bson.M{
+				bson.M{"$match": query},
+				bson.M{"$unwind": fieldPath},
+				bson.M{"$sort": bson.M{"_id": 1}},
+			}
+			return mgoSession.DB("").C(c).Pipe(pipeline).AllowDiskUse()
+		}
+	}
+	return mgoSession.DB("").C(c).Pipe([]bson.M{
+		bson.M{"$match": query},
+		bson.M{"$sort": bson.M{"_id": 1}},
+	}).AllowDiskUse()
 }
 
 func (r *Reader) requeryable(c string, mgoSession *mgo.Session) bool {
@@ -289,6 +308,7 @@ func (r *Reader) tailCollection(c string, mgoSession *mgo.Session, oplogTime bso
 	return errc
 }
 
+// TODO improve with aggregation
 // getOriginalDoc retrieves the original document from the database.
 // transporter has no knowledge of update operations, all updates work as wholesale document replaces
 func (r *Reader) getOriginalDoc(doc bson.M, c string, s *mgo.Session) (result bson.M, err error) {

--- a/adaptor/mongodb/reader_test.go
+++ b/adaptor/mongodb/reader_test.go
@@ -32,7 +32,7 @@ func TestRead(t *testing.T) {
 		t.Skip("skipping Read in short mode")
 	}
 
-	reader := newReader(false, DefaultCollectionFilter)
+	reader := newReader(false, DefaultCollectionFilter, DefaultUnwind)
 	readFunc := reader.Read(filterFunc)
 	done := make(chan struct{})
 	c, _ := NewClient(WithURI(fmt.Sprintf("mongodb://127.0.0.1:27017/%s", readerTestData.DB)))
@@ -63,6 +63,7 @@ func TestFilteredRead(t *testing.T) {
 	reader := newReader(
 		false,
 		map[string]CollectionFilter{"foo": CollectionFilter{"i": map[string]interface{}{"$gt": filteredReaderTestData.InsertCount}}},
+		DefaultUnwind,
 	)
 
 	for i := filteredReaderTestData.InsertCount; i <= 100; i++ {
@@ -97,7 +98,7 @@ func TestCancelledRead(t *testing.T) {
 		t.Skip("skipping TestCancelledRead in short mode")
 	}
 
-	reader := newReader(false, DefaultCollectionFilter)
+	reader := newReader(false, DefaultCollectionFilter, DefaultUnwind)
 	readFunc := reader.Read(filterFunc)
 	done := make(chan struct{})
 	c, _ := NewClient(WithURI(fmt.Sprintf("mongodb://127.0.0.1:27017/%s", cancelledReaderTestData.DB)))
@@ -153,7 +154,7 @@ func TestReadRestart(t *testing.T) {
 		session.mgoSession.DB(db).C("lotsodata").Insert(bson.M{"i": i})
 	}
 
-	reader := newReader(false, DefaultCollectionFilter)
+	reader := newReader(false, DefaultCollectionFilter, DefaultUnwind)
 	readFunc := reader.Read(filterFunc)
 	done := make(chan struct{})
 	msgChan, err := readFunc(s, done)
@@ -237,7 +238,7 @@ func TestTail(t *testing.T) {
 		t.Fatalf("unexpected insertMockTailData error, %s\n", err)
 	}
 
-	tail := newReader(true, DefaultCollectionFilter)
+	tail := newReader(true, DefaultCollectionFilter, DefaultUnwind)
 
 	time.Sleep(1 * time.Second)
 	tailFunc := tail.Read(func(c string) bool {


### PR DESCRIPTION
$unwind Deconstructs an array field from the input documents to output a document for each element. Each output document is the input document with the value of the array field replaced by the element.

### Required for all PRs:

- [ ] CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)
- [x] README.md updated (if needed)
