### PR TITLE
full test coverage for log pkg

### DIFF
--- a/log/logger.go
+++ b/log/logger.go
@@ -5,8 +5,6 @@ package log
 import (
 	"flag"
 	"fmt"
-	"io"
-	"io/ioutil"
 
 	"github.com/Sirupsen/logrus"
 )
@@ -114,20 +112,6 @@ func Orig() *logrus.Logger {
 // Base returns the default Logger logging to
 func Base() Logger {
 	return baseLogger
-}
-
-// NewLogger returns a new Logger logging to out.
-func NewLogger(w io.Writer) Logger {
-	l := logrus.New()
-	l.Out = w
-	return logger{entry: logrus.NewEntry(l)}
-}
-
-// NewNopLogger returns a logger that discards all log messages.
-func NewNopLogger() Logger {
-	l := logrus.New()
-	l.Out = ioutil.Discard
-	return logger{entry: logrus.NewEntry(l)}
 }
 
 // With adds a field to the logger.

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -1,26 +1,98 @@
-package log
+package log_test
 
 import (
 	"bytes"
+	"flag"
 	"regexp"
 	"testing"
 
 	"github.com/Sirupsen/logrus"
+
+	"github.com/compose/transporter/log"
+)
+
+var (
+	loggerTests = []struct {
+		logLines func()
+		logLevel logrus.Level
+		re       *regexp.Regexp
+	}{
+		{
+			func() {
+				log.Base().Debugln("This debug-level line should not show up in the output.")
+				log.Base().Infof("This %s-level line should show up in the output.", "info")
+			},
+			logrus.InfoLevel,
+			regexp.MustCompile(`^time=".*" level=info msg="This info-level line should show up in the output." \n$`),
+		},
+		{
+			func() {
+				log.Debugf("This %s-level line should show up in the output.", "debug")
+			},
+			logrus.DebugLevel,
+			regexp.MustCompile(`^time=".*" level=debug msg="This debug-level line should show up in the output." \n$`),
+		},
+		{
+			func() {
+				log.Debugln("This debug-level line should not show up in the output.")
+				log.Infof("This %s-level line should not show up in the output.", "info")
+				log.Errorf("This %s-level line should show up in the output.", "error")
+			},
+			logrus.ErrorLevel,
+			regexp.MustCompile(`^time=".*" level=error msg="This error-level line should show up in the output." \n$`),
+		},
+		{
+			func() {
+				log.Errorln("This error-level line should show up in the output.")
+				log.Infoln("This info-level line should not show up in the output.")
+			},
+			logrus.ErrorLevel,
+			regexp.MustCompile(`^time=".*" level=error msg="This error-level line should show up in the output." \n$`),
+		},
+		{
+			func() {
+				log.With("key", "value").Infoln("This info-level line should show up in the output.")
+			},
+			logrus.InfoLevel,
+			regexp.MustCompile(`^time=".*" level=info msg="This info-level line should show up in the output." key=value \n$`),
+		},
+		{
+			func() {
+				log.Base().Output(0, "This info-level line should show up in the output.")
+			},
+			logrus.InfoLevel,
+			regexp.MustCompile(`^time=".*" level=info msg="This info-level line should show up in the output." \n$`),
+		},
+	}
 )
 
 func TestFileLineLogging(t *testing.T) {
-	var buf bytes.Buffer
-	origLogger.Out = &buf
-	origLogger.Formatter = &logrus.TextFormatter{
-		DisableColors: true,
-	}
+	for _, lt := range loggerTests {
+		var buf bytes.Buffer
+		log.Orig().Out = &buf
+		log.Orig().Level = lt.logLevel
+		log.Orig().Formatter = &logrus.TextFormatter{
+			DisableColors: true,
+		}
 
-	// The default logging level should be "info".
-	Debugln("This debug-level line should not show up in the output.")
-	Infof("This %s-level line should show up in the output.", "info")
+		lt.logLines()
 
-	re := `^time=".*" level=info msg="This info-level line should show up in the output." \n$`
-	if !regexp.MustCompile(re).Match(buf.Bytes()) {
-		t.Fatalf("%q did not match expected regex %q", buf.String(), re)
+		if !lt.re.Match(buf.Bytes()) {
+			t.Fatalf("%q did not match expected regex %q", buf.String(), lt.re.String())
+		}
 	}
+}
+
+func TestCommandLineFlag(t *testing.T) {
+	if err := flag.Set("log.level", "error"); err != nil {
+		t.Fatalf("unexpected flag.Set error, %s", err)
+	}
+	flag.Parse()
+}
+
+func TestCommandLineFlagErr(t *testing.T) {
+	if err := flag.Set("log.level", "erro"); err == nil {
+		t.Fatal("expected flag.Set error, none received")
+	}
+	flag.Parse()
 }


### PR DESCRIPTION
this will helps us get a better baseline for the project since the `log` package had such low coverage