### PR TITLE
rethinkdb writer: use msg.Confirms() to guarantee writes

### DIFF
--- a/adaptor/rethinkdb/writer.go
+++ b/adaptor/rethinkdb/writer.go
@@ -30,8 +30,9 @@ type Writer struct {
 }
 
 type bulkOperation struct {
-	s    *r.Session
-	docs []map[string]interface{}
+	s        *r.Session
+	confirms chan struct{}
+	docs     []map[string]interface{}
 }
 
 func newWriter(done chan struct{}, wg *sync.WaitGroup) *Writer {
@@ -51,7 +52,11 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 		switch msg.OP() {
 		case ops.Delete:
 			w.flushAll()
-			return msg, do(r.DB(rSession.Database()).Table(table).Get(prepareDocument(msg)["id"]).Delete(), rSession)
+			return msg, do(
+				r.DB(rSession.Database()).Table(table).Get(prepareDocument(msg)["id"]).Delete(),
+				rSession,
+				msg.Confirms(),
+			)
 		case ops.Insert:
 			w.Lock()
 			bOp, ok := w.bulkMap[table]
@@ -62,6 +67,9 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 				}
 				w.bulkMap[table] = bOp
 			}
+			if msg.Confirms() != nil {
+				bOp.confirms = msg.Confirms()
+			}
 			bOp.docs = append(bOp.docs, prepareDocument(msg))
 			w.Unlock()
 			w.opCounter++
@@ -70,7 +78,11 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 			}
 		case ops.Update:
 			w.flushAll()
-			return msg, do(r.DB(rSession.Database()).Table(table).Insert(prepareDocument(msg), r.InsertOpts{Conflict: "replace"}), rSession)
+			return msg, do(
+				r.DB(rSession.Database()).Table(table).Insert(prepareDocument(msg), r.InsertOpts{Conflict: "replace"}),
+				rSession,
+				msg.Confirms(),
+			)
 		}
 		return msg, nil
 	}
@@ -118,7 +130,7 @@ func (w *Writer) flushAll() error {
 		if err != nil {
 			return err
 		}
-		if err := handleResponse(&resp); err != nil {
+		if err := handleResponse(&resp, bOp.confirms); err != nil {
 			return err
 		}
 	}
@@ -126,20 +138,23 @@ func (w *Writer) flushAll() error {
 	return nil
 }
 
-func do(t r.Term, s *r.Session) error {
+func do(t r.Term, s *r.Session, confirms chan struct{}) error {
 	resp, err := t.RunWrite(s)
 	if err != nil {
 		return err
 	}
-	return handleResponse(&resp)
+	return handleResponse(&resp, confirms)
 }
 
 // handleresponse takes the rethink response and turn it into something we can consume elsewhere
-func handleResponse(resp *r.WriteResponse) error {
+func handleResponse(resp *r.WriteResponse, confirms chan struct{}) error {
 	if resp.Errors != 0 {
 		if !strings.Contains(resp.FirstError, "Duplicate primary key") { // we don't care about this error
 			return fmt.Errorf("%s\n%s", "problem inserting docs", resp.FirstError)
 		}
+	}
+	if confirms != nil {
+		close(confirms)
 	}
 	return nil
 }

--- a/pipeline/node_test.go
+++ b/pipeline/node_test.go
@@ -649,29 +649,41 @@ func TestStop(t *testing.T) {
 	for _, st := range stopTests {
 		source, s, deferFunc := st.node()
 		defer deferFunc()
-		var errored bool
+		var errorChecked bool
 		stopC := make(chan struct{})
-		go func() {
+		var mu sync.Mutex
+		go func(mu *sync.Mutex) {
 			select {
 			case <-source.pipe.Err:
-				errored = true
+				mu.Lock()
+				defer mu.Unlock()
+				if errorChecked {
+					return
+				}
+				errorChecked = true
+				time.Sleep(1 * time.Second)
 				source.Stop()
 				close(stopC)
 			}
-		}()
+		}(&mu)
 		if err := source.Start(); err != st.startErr {
 			t.Errorf("[%s] unexpected Start() error, expected %s, got %s", st.name, st.startErr, err)
 		}
-		if !errored {
+		mu.Lock()
+		if !errorChecked {
+			errorChecked = true
+			time.Sleep(1 * time.Second)
 			source.Stop()
 			close(stopC)
 		}
+		mu.Unlock()
 		<-stopC
 		for _, child := range source.children {
 			if !s.Closed {
 				t.Errorf("[%s] child node was not closed but should have been", child.Name)
 			}
 		}
+
 		if st.msgCount != s.MsgCount {
 			t.Errorf("[%s] wrong number of messages received, expected %d, got %d", st.name, st.msgCount, s.MsgCount)
 		}

--- a/pipeline/pipeline_events_integration_test.go
+++ b/pipeline/pipeline_events_integration_test.go
@@ -53,6 +53,7 @@ func TestEventsBroadcast(t *testing.T) {
 	eh := &EventHolder{rawEvents: make([][]byte, 0)}
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		event, _ := ioutil.ReadAll(r.Body)
+		fmt.Println(string(event))
 		r.Body.Close()
 		eh.rawEvents = append(eh.rawEvents, event)
 	}))
@@ -103,7 +104,7 @@ func TestEventsBroadcast(t *testing.T) {
 		t.Fatalf("can't create NewNode, got %s", err)
 	}
 
-	p, err := NewDefaultPipeline(dummyOutNode, ts.URL, "asdf", "jklm", "test", 1*time.Second)
+	p, err := NewDefaultPipeline(dummyOutNode, ts.URL, "asdf", "jklm", "test", 10*time.Second)
 	if err != nil {
 		t.Errorf("can't create pipeline, got %s", err.Error())
 		t.FailNow()


### PR DESCRIPTION
while adding the rethinkdb writer confirms, it became clear the changes to the pipe were creating cases where messages could not be delivered.