### PR TITLE
Cleanup items

### DIFF
--- a/adaptor/elasticsearch/clients/v2/writer.go
+++ b/adaptor/elasticsearch/clients/v2/writer.go
@@ -56,9 +56,9 @@ func init() {
 		p, err := esClient.BulkProcessor().
 			Name("TransporterWorker-1").
 			Workers(2).
-			BulkActions(1000).               // commit if # requests >= 1000
-			BulkSize(2 << 20).               // commit if size of requests >= 2 MB
-			FlushInterval(30 * time.Second). // commit every 30s
+			BulkActions(1000).              // commit if # requests >= 1000
+			BulkSize(2 << 20).              // commit if size of requests >= 2 MB
+			FlushInterval(5 * time.Second). // commit every 5s
 			Before(w.preBulkProcessor).
 			After(w.postBulkProcessor).
 			Do(context.TODO())
@@ -117,7 +117,7 @@ func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableReq
 			With("took", fmt.Sprintf("%dms", resp.Took)).
 			With("succeeeded", len(resp.Succeeded())).
 			With("failed", len(resp.Failed())).
-			Infoln("_bulk flush completed")
+			Debugln("_bulk flush completed")
 		if w.confirmChan != nil && len(resp.Failed()) == 0 {
 			close(w.confirmChan)
 			w.confirmChan = nil

--- a/adaptor/elasticsearch/clients/v5/writer.go
+++ b/adaptor/elasticsearch/clients/v5/writer.go
@@ -56,9 +56,9 @@ func init() {
 		p, err := esClient.BulkProcessor().
 			Name("TransporterWorker-1").
 			Workers(2).
-			BulkActions(1000).               // commit if # requests >= 1000
-			BulkSize(2 << 20).               // commit if size of requests >= 2 MB
-			FlushInterval(30 * time.Second). // commit every 30s
+			BulkActions(1000).              // commit if # requests >= 1000
+			BulkSize(2 << 20).              // commit if size of requests >= 2 MB
+			FlushInterval(5 * time.Second). // commit every 5s
 			Before(w.preBulkProcessor).
 			After(w.postBulkProcessor).
 			Do(context.TODO())
@@ -117,7 +117,7 @@ func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableReq
 			With("took", fmt.Sprintf("%dms", resp.Took)).
 			With("succeeeded", len(resp.Succeeded())).
 			With("failed", len(resp.Failed())).
-			Infoln("_bulk flush completed")
+			Debugln("_bulk flush completed")
 		if w.confirmChan != nil && len(resp.Failed()) == 0 {
 			close(w.confirmChan)
 			w.confirmChan = nil

--- a/adaptor/mongodb/bulk.go
+++ b/adaptor/mongodb/bulk.go
@@ -134,7 +134,7 @@ func (b *Bulk) flushAll() error {
 }
 
 func (b *Bulk) flush(c string, bOp *bulkOperation) error {
-	log.With("collection", c).With("opCounter", bOp.opCounter).With("bsonOpSize", bOp.bsonOpSize).Infoln("flushing bulk messages")
+	log.With("collection", c).With("opCounter", bOp.opCounter).With("bsonOpSize", bOp.bsonOpSize).Debugln("flushing bulk messages")
 	_, err := bOp.bulk.Run()
 	if err != nil && !mgo.IsDup(err) {
 		log.With("collection", c).Errorf("flush error, %s\n", err)
@@ -147,7 +147,7 @@ func (b *Bulk) flush(c string, bOp *bulkOperation) error {
 		}
 	}
 	bOp.s.Close()
-	log.With("collection", c).Infoln("flush complete")
+	log.With("collection", c).Debugln("flush complete")
 	delete(b.bulkMap, c)
 	return nil
 }

--- a/cmd/transporter/goja_builder.go
+++ b/cmd/transporter/goja_builder.go
@@ -93,7 +93,7 @@ type Adaptor struct {
 
 func (t *Transporter) Run() error {
 	var g group.Group
-	p, err := pipeline.NewPipeline(version, t.sourceNode, events.LogEmitter(), 60*time.Second)
+	p, err := pipeline.NewPipeline(version, t.sourceNode, events.LogEmitter(), 5*time.Second)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
a few changes based on various tests, some of these will be converted to configuration options in the future

most notable change is tracking of the oplog time in mongodb reader, this fixes an unreported bug where changes to a document could not have been picked up when tailing the oplog started after copying a collection