### PR TITLE
new Config function in JS DSL

### DIFF
--- a/cmd/transporter/run.go
+++ b/cmd/transporter/run.go
@@ -13,14 +13,10 @@ func runRun(args []string) error {
 		args = []string{defaultPipelineFile}
 	}
 
-	builder, err := NewBuilder(args[0])
+	builder, err := newBuilder(args[0])
 	if err != nil {
 		return err
 	}
 
-	if err := builder.Run(); err != nil {
-		return err
-	}
-
-	return nil
+	return builder.run()
 }

--- a/cmd/transporter/test.go
+++ b/cmd/transporter/test.go
@@ -17,7 +17,7 @@ func runTest(args []string) error {
 		args = []string{defaultPipelineFile}
 	}
 
-	builder, err := NewBuilder(args[0])
+	builder, err := newBuilder(args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/transporter/testdata/test_pipeline.js
+++ b/cmd/transporter/testdata/test_pipeline.js
@@ -1,4 +1,4 @@
 m = mongodb({"uri": "mongo://localhost:27017"})
-t.Source("source", m)
+t.Config({"data_dir":"/tmp/test"}).Source("source", m)
   .Transform("trans", transformer({filename: "pipeline.js"}))
   .Save("sink", elasticsearch({uri:"http://localhost:9200"}))

--- a/commitlog/compactor.go
+++ b/commitlog/compactor.go
@@ -38,9 +38,9 @@ func (c *NamespaceCompactor) Compact(offset uint64, segments []*Segment) {
 
 func (c *NamespaceCompactor) compactSegment(offset uint64, wg *sync.WaitGroup, segment *Segment) {
 	defer wg.Done()
-	if err := segment.Open(); err != nil {
-		log.With("segment", segment.path).Errorf("unable to open segment, %s", err)
-	}
+	// if err := segment.Open(); err != nil {
+	// 	log.With("segment", segment.path).Errorf("unable to open segment, %s", err)
+	// }
 	r := &segmentReader{s: segment, position: 0}
 	entryMap := make(map[string]LogEntry)
 	for {

--- a/commitlog/reader.go
+++ b/commitlog/reader.go
@@ -40,10 +40,10 @@ func (r *Reader) Read(p []byte) (int, error) {
 		r.idx++
 		segment = segments[r.idx]
 		r.position = 0
-		err = segment.Open()
-		if err != nil {
-			break
-		}
+		// err = segment.Open()
+		// if err != nil {
+		// 	break
+		// }
 	}
 
 	return n, err

--- a/commitlog/segment.go
+++ b/commitlog/segment.go
@@ -146,18 +146,18 @@ func (s *Segment) ReadAt(p []byte, off int64) (n int, err error) {
 	return s.log.ReadAt(p, off)
 }
 
-func (s *Segment) Open() error {
-	s.Lock()
-	defer s.Unlock()
-	l, err := os.OpenFile(s.path, os.O_RDWR, 0666)
-	if err != nil {
-		return err
-	}
-	s.log = l
-	s.reader = l
-	s.writer = l
-	return nil
-}
+// func (s *Segment) Open() error {
+// 	s.Lock()
+// 	defer s.Unlock()
+// 	l, err := os.OpenFile(s.path, os.O_RDWR, 0666)
+// 	if err != nil {
+// 		return err
+// 	}
+// 	s.log = l
+// 	s.reader = l
+// 	s.writer = l
+// 	return nil
+// }
 
 // Close closes the read/write access to the underlying file.
 func (s *Segment) Close() error {

--- a/offset/logmanager.go
+++ b/offset/logmanager.go
@@ -54,7 +54,7 @@ func NewLogManager(path, name string) (*LogManager, error) {
 func (m *LogManager) buildMap() error {
 	var lastError error
 	for _, s := range m.log.Segments() {
-		s.Open()
+		// s.Open()
 		var readPosition int64
 		for {
 			// skip the offsetHeader
@@ -118,6 +118,7 @@ func (m *LogManager) OffsetMap() map[string]uint64 {
 	return m.nsMap
 }
 
+// NewestOffset loops over every offset and returns the highest one.
 func (m *LogManager) NewestOffset() int64 {
 	m.Lock()
 	defer m.Unlock()

--- a/pipeline/node_test.go
+++ b/pipeline/node_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/compose/transporter/adaptor"
 	"github.com/compose/transporter/client"
+	"github.com/compose/transporter/commitlog"
 	"github.com/compose/transporter/function"
 	"github.com/compose/transporter/log"
 	"github.com/compose/transporter/message"
@@ -207,7 +208,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog(dataDir, 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath(dataDir),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -230,7 +234,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog(dataDir, 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath(dataDir),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -254,7 +261,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog(dataDir, 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath(dataDir),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -284,7 +294,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog(dataDir, 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath(dataDir),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -314,7 +327,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog(dataDir, 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath(dataDir),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -344,7 +360,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog(dataDir, 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath(dataDir),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -374,7 +393,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_zero", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_zero"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager(dataDir, "stopper")
 				NewNodeWithOptions(
@@ -407,7 +429,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_middle", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_middle"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager("testdata/restart_from_middle", "stopper")
 				NewNodeWithOptions(
@@ -429,7 +454,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_end", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_end"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				om, _ := offset.NewLogManager("testdata/restart_from_end", "stopper")
 				NewNodeWithOptions(
@@ -451,7 +479,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_zero", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_zero"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", defaultNsString,
@@ -474,7 +505,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_zero", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_zero"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", defaultNsString,
@@ -501,7 +535,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_zero", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_zero"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", defaultNsString,
@@ -528,7 +565,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_zero", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_zero"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", defaultNsString,
@@ -557,7 +597,10 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/pipeline_run", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/pipeline_run"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", "/blah/",
@@ -580,7 +623,10 @@ var (
 					"ctxStarter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/pipeline_run", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/pipeline_run"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"ctxStopper", "stopWriter", defaultNsString,
@@ -604,7 +650,10 @@ var (
 					"ctx_cancel_starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/restart_from_zero", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/restart_from_zero"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"ctx_cancel_stopper", "stopWriter", defaultNsString,
@@ -626,7 +675,10 @@ var (
 					"offset_commit_err_starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/pipeline_run", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/pipeline_run"),
+						commitlog.WithMaxSegmentBytes(1024),
+					}...),
 				)
 				NewNodeWithOptions(
 					"offset_commit_err_stopper", "stopWriter", defaultNsString,

--- a/pipeline/pipeline_events_integration_test.go
+++ b/pipeline/pipeline_events_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/compose/transporter/adaptor"
+	"github.com/compose/transporter/commitlog"
 	"github.com/compose/transporter/offset"
 )
 
@@ -80,7 +81,9 @@ func TestEventsBroadcast(t *testing.T) {
 		"dummyFileOut", "file", "/.*",
 		WithClient(f),
 		WithReader(f),
-		WithCommitLog(dataDir, 1024*1024*1024),
+		WithCommitLog([]commitlog.OptionFunc{
+			commitlog.WithPath(dataDir),
+		}...),
 	)
 	if err != nil {
 		t.Fatalf("can't create NewNode, got %s", err)

--- a/pipeline/pipeline_integration_test.go
+++ b/pipeline/pipeline_integration_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/compose/transporter/adaptor"
 	_ "github.com/compose/transporter/adaptor/all"
+	"github.com/compose/transporter/commitlog"
 	"github.com/compose/transporter/events"
 	"github.com/compose/transporter/offset"
 )
@@ -55,7 +56,9 @@ func TestFileToFile(t *testing.T) {
 		"localfileout", "file", "/.*",
 		WithClient(f),
 		WithReader(f),
-		WithCommitLog(dataDir, 1024*1024*1024),
+		WithCommitLog([]commitlog.OptionFunc{
+			commitlog.WithPath(dataDir),
+		}...),
 	)
 	if err != nil {
 		t.Fatalf("can't create newnode, got %s", err)

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/compose/transporter/adaptor"
 	_ "github.com/compose/transporter/adaptor/file"
 	"github.com/compose/transporter/client"
+	"github.com/compose/transporter/commitlog"
 	"github.com/compose/transporter/events"
 	"github.com/compose/transporter/offset"
 )
@@ -87,7 +88,9 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
-					WithCommitLog("testdata/pipeline_run", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/pipeline_run"),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", defaultNsString,
@@ -107,7 +110,9 @@ var (
 					"starter", "stopWriter", defaultNsString,
 					WithClient(&adaptor.MockClientErr{}),
 					WithReader(a),
-					WithCommitLog("testdata/pipeline_run", 1024),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/pipeline_run"),
+					}...),
 				)
 				NewNodeWithOptions(
 					"stopper", "stopWriter", defaultNsString,


### PR DESCRIPTION
- add commit log options to JS DSL with a new `Config()` function attached to the root `transporter` object
- revert open/close of segments (had some bugs, will fix soon)
- fix bug with multi NS tracking: due to the way offsets are tracked and messages copied, it was possible for transporter to send duplicate messages upon restart, this was fixed in `pipeline.Node` by overriding the `Mode` value provided to readers if the namespace was not associated with the last offset committed
