### PR TITLE
wire up log compaction with configurable interval

### DIFF
--- a/adaptor/elasticsearch/clients/v1/writer.go
+++ b/adaptor/elasticsearch/clients/v1/writer.go
@@ -70,7 +70,7 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 			_, err = w.esClient.Index().Index(w.index).Type(indexType).BodyJson(msg.Data()).Id(id).Do(context.TODO())
 		}
 		if msg.Confirms() != nil && err == nil {
-			close(msg.Confirms())
+			msg.Confirms() <- struct{}{}
 		}
 		return msg, err
 	}

--- a/adaptor/elasticsearch/clients/v1/writer_test.go
+++ b/adaptor/elasticsearch/clients/v1/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/compose/transporter/adaptor"
 	"github.com/compose/transporter/adaptor/elasticsearch/clients"
 	"github.com/compose/transporter/log"
 	"github.com/compose/transporter/message"
@@ -65,6 +66,8 @@ type countResponse struct {
 }
 
 func TestWriter(t *testing.T) {
+	confirms, cleanup := adaptor.MockConfirmWrites()
+	defer adaptor.VerifyWriteConfirmed(cleanup, t)
 	opts := &clients.ClientOptions{
 		URLs:       []string{testURL},
 		HTTPClient: http.DefaultClient,
@@ -74,22 +77,22 @@ func TestWriter(t *testing.T) {
 	w, _ := vc.Creator(opts)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Insert, testType, map[string]interface{}{"hello": "world"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Insert, testType, map[string]interface{}{"_id": "booya", "hello": "world"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Update, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Delete, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
 	)(nil)
 

--- a/adaptor/elasticsearch/clients/v2/writer.go
+++ b/adaptor/elasticsearch/clients/v2/writer.go
@@ -119,8 +119,7 @@ func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableReq
 			With("failed", len(resp.Failed())).
 			Debugln("_bulk flush completed")
 		if w.confirmChan != nil && len(resp.Failed()) == 0 {
-			close(w.confirmChan)
-			w.confirmChan = nil
+			w.confirmChan <- struct{}{}
 		}
 	}
 	if err != nil {

--- a/adaptor/elasticsearch/clients/v2/writer_test.go
+++ b/adaptor/elasticsearch/clients/v2/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/compose/transporter/adaptor"
 	"github.com/compose/transporter/adaptor/elasticsearch/clients"
 	"github.com/compose/transporter/client"
 	"github.com/compose/transporter/log"
@@ -66,6 +67,8 @@ type countResponse struct {
 }
 
 func TestWriter(t *testing.T) {
+	confirms, cleanup := adaptor.MockConfirmWrites()
+	defer adaptor.VerifyWriteConfirmed(cleanup, t)
 	opts := &clients.ClientOptions{
 		URLs:       []string{testURL},
 		HTTPClient: http.DefaultClient,
@@ -75,22 +78,22 @@ func TestWriter(t *testing.T) {
 	w, _ := vc.Creator(opts)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Insert, testType, map[string]interface{}{"hello": "world"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Insert, testType, map[string]interface{}{"_id": "booya", "hello": "world"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Update, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Delete, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
 	)(nil)
 	w.(client.Closer).Close()

--- a/adaptor/elasticsearch/clients/v5/writer.go
+++ b/adaptor/elasticsearch/clients/v5/writer.go
@@ -119,8 +119,7 @@ func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableReq
 			With("failed", len(resp.Failed())).
 			Debugln("_bulk flush completed")
 		if w.confirmChan != nil && len(resp.Failed()) == 0 {
-			close(w.confirmChan)
-			w.confirmChan = nil
+			w.confirmChan <- struct{}{}
 		}
 	}
 	if err != nil {

--- a/adaptor/elasticsearch/clients/v5/writer_test.go
+++ b/adaptor/elasticsearch/clients/v5/writer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/compose/transporter/adaptor"
 	"github.com/compose/transporter/adaptor/elasticsearch/clients"
 	"github.com/compose/transporter/client"
 	"github.com/compose/transporter/log"
@@ -66,6 +67,8 @@ type countResponse struct {
 }
 
 func TestWriter(t *testing.T) {
+	confirms, cleanup := adaptor.MockConfirmWrites()
+	defer adaptor.VerifyWriteConfirmed(cleanup, t)
 	opts := &clients.ClientOptions{
 		URLs:       []string{testURL},
 		HTTPClient: http.DefaultClient,
@@ -75,22 +78,22 @@ func TestWriter(t *testing.T) {
 	w, _ := vc.Creator(opts)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Insert, testType, map[string]interface{}{"hello": "world"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Insert, testType, map[string]interface{}{"_id": "booya", "hello": "world"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Update, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
 	)(nil)
 	w.Write(
 		message.WithConfirms(
-			make(chan struct{}),
+			confirms,
 			message.From(ops.Delete, testType, map[string]interface{}{"_id": "booya", "hello": "goodbye"})),
 	)(nil)
 	w.(client.Closer).Close()

--- a/adaptor/file/writer.go
+++ b/adaptor/file/writer.go
@@ -24,7 +24,7 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 			return nil, err
 		}
 		if msg.Confirms() != nil {
-			close(msg.Confirms())
+			msg.Confirms() <- struct{}{}
 		}
 		return msg, nil
 	}

--- a/adaptor/file/writer_test.go
+++ b/adaptor/file/writer_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/compose/transporter/adaptor"
 	"github.com/compose/transporter/message"
 	"github.com/compose/transporter/message/ops"
 )
@@ -23,11 +24,13 @@ func TestWrite(t *testing.T) {
 	}
 	defer f.Close()
 	tmpSession := &Session{file: f}
+	confirms, cleanup := adaptor.MockConfirmWrites()
+	defer adaptor.VerifyWriteConfirmed(cleanup, t)
 	w := newWriter()
 	for i := 0; i < 2; i++ {
 		msg := message.From(ops.Insert, "test", map[string]interface{}{"_id": "546656989330a846dc7ce327", "test": "hello world"})
 		if i == 0 {
-			msg = message.WithConfirms(make(chan struct{}), msg)
+			msg = message.WithConfirms(confirms, msg)
 		}
 		if _, err := w.Write(msg)(tmpSession); err != nil {
 			t.Errorf("unexpected Write error, %s\n", err)

--- a/adaptor/mongodb/bulk.go
+++ b/adaptor/mongodb/bulk.go
@@ -126,8 +126,7 @@ func (b *Bulk) flushAll() error {
 		}
 	}
 	if b.confirmChan != nil {
-		close(b.confirmChan)
-		b.confirmChan = nil
+		b.confirmChan <- struct{}{}
 	}
 	b.Unlock()
 	return nil

--- a/adaptor/mongodb/bulk_test.go
+++ b/adaptor/mongodb/bulk_test.go
@@ -1,7 +1,6 @@
 package mongodb
 
 import (
-	"context"
 	"crypto/rand"
 	"fmt"
 	"sync"
@@ -10,6 +9,7 @@ import (
 
 	"gopkg.in/mgo.v2/bson"
 
+	"github.com/compose/transporter/adaptor"
 	"github.com/compose/transporter/message"
 	"github.com/compose/transporter/message/ops"
 )
@@ -40,18 +40,9 @@ func checkBulkCount(c string, countQuery bson.M, expectedCount int, t *testing.T
 	}
 }
 
-func confirmWrite(ctx context.Context, confirmed chan struct{}) {
-	for {
-		select {
-		case <-confirmed:
-			return
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
 func TestBulkWrite(t *testing.T) {
+	confirms, cleanup := adaptor.MockConfirmWrites()
+	defer adaptor.VerifyWriteConfirmed(cleanup, t)
 	var wg sync.WaitGroup
 	done := make(chan struct{})
 	b := newBulker(done, &wg)
@@ -68,9 +59,6 @@ func TestBulkWrite(t *testing.T) {
 			for k, v := range bt.extraData {
 				data[k] = v
 			}
-			confirms := make(chan struct{})
-			ctx, _ := context.WithTimeout(context.TODO(), 5*time.Second)
-			go confirmWrite(ctx, confirms)
 			b.Write(message.WithConfirms(confirms, message.From(bt.op, bulkTestData.C, data)))(s)
 		}
 		time.Sleep(3 * time.Second)
@@ -131,6 +119,8 @@ func TestBulkOpCount(t *testing.T) {
 }
 
 func TestBulkIsDup(t *testing.T) {
+	confirms, cleanup := adaptor.MockConfirmWrites()
+	defer adaptor.VerifyWriteConfirmed(cleanup, t)
 	var wg sync.WaitGroup
 	done := make(chan struct{})
 	b := newBulker(done, &wg)
@@ -144,7 +134,7 @@ func TestBulkIsDup(t *testing.T) {
 	for i := 0; i < testBulkMsgCount; i++ {
 		b.Write(
 			message.WithConfirms(
-				make(chan struct{}),
+				confirms,
 				message.From(ops.Insert, "dupErr", map[string]interface{}{"_id": i, "i": i}),
 			),
 		)(s)
@@ -155,7 +145,7 @@ func TestBulkIsDup(t *testing.T) {
 	for i := 0; i < (2 * testBulkMsgCount); i++ {
 		b.Write(
 			message.WithConfirms(
-				make(chan struct{}),
+				confirms,
 				message.From(ops.Insert, "dupErr", map[string]interface{}{"_id": i, "i": i}),
 			),
 		)(s)

--- a/adaptor/mongodb/writer.go
+++ b/adaptor/mongodb/writer.go
@@ -32,7 +32,7 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 		if !ok {
 			log.Infof("no function registered for operation, %s\n", msg.OP())
 			if msg.Confirms() != nil {
-				close(msg.Confirms())
+				msg.Confirms() <- struct{}{}
 			}
 			return msg, nil
 		}
@@ -40,7 +40,7 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 			return nil, err
 		}
 		if msg.Confirms() != nil {
-			close(msg.Confirms())
+			msg.Confirms() <- struct{}{}
 		}
 		return msg, nil
 	}

--- a/adaptor/postgres/writer.go
+++ b/adaptor/postgres/writer.go
@@ -36,7 +36,7 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 		if !ok {
 			log.Infof("no function registered for operation, %s", msg.OP())
 			if msg.Confirms() != nil {
-				close(msg.Confirms())
+				msg.Confirms() <- struct{}{}
 			}
 			return msg, nil
 		}
@@ -44,7 +44,7 @@ func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error
 			return nil, err
 		}
 		if msg.Confirms() != nil {
-			close(msg.Confirms())
+			msg.Confirms() <- struct{}{}
 		}
 		return msg, nil
 	}

--- a/adaptor/rabbitmq/writer_test.go
+++ b/adaptor/rabbitmq/writer_test.go
@@ -82,7 +82,7 @@ func TestWriteWithEmptyKey(t *testing.T) {
 }
 
 func checkQueueCount(queue string, count int, t *testing.T) {
-	time.Sleep(2 * time.Second)
+	time.Sleep(5 * time.Second)
 	u, _ := url.Parse(DefaultURI)
 	vhost := u.Path
 	if vhost != "/" {

--- a/adaptor/rethinkdb/writer.go
+++ b/adaptor/rethinkdb/writer.go
@@ -154,7 +154,7 @@ func handleResponse(resp *r.WriteResponse, confirms chan struct{}) error {
 		}
 	}
 	if confirms != nil {
-		close(confirms)
+		confirms <- struct{}{}
 	}
 	return nil
 }

--- a/client/testing.go
+++ b/client/testing.go
@@ -76,7 +76,7 @@ func (w *MockWriter) Write(msg message.Msg) func(Session) (message.Msg, error) {
 	return func(s Session) (message.Msg, error) {
 		w.MsgCount++
 		if msg.Confirms() != nil {
-			close(msg.Confirms())
+			msg.Confirms() <- struct{}{}
 		}
 		return msg, nil
 	}

--- a/cmd/transporter/goja_builder.go
+++ b/cmd/transporter/goja_builder.go
@@ -82,8 +82,9 @@ type Transporter struct {
 }
 
 type config struct {
-	LogDir          string `json:"log_dir"`
-	MaxSegmentBytes int    `json:"max_segment_bytes"`
+	LogDir             string `json:"log_dir"`
+	MaxSegmentBytes    int    `json:"max_segment_bytes"`
+	CompactionInterval string `json:"compaction_interval"`
 }
 
 // Node encapsulates a sink/source node in the pipeline.
@@ -169,6 +170,8 @@ func buildFunction(name string) func(map[string]interface{}) function.Function {
 	}
 }
 
+// Config parses the provided configuration object and associates it with the
+// JS VM.
 func (t *Transporter) Config(call goja.FunctionCall) goja.Value {
 	if cfg, ok := call.Argument(0).Export().(map[string]interface{}); ok {
 		b, err := json.Marshal(cfg)
@@ -192,6 +195,7 @@ func (t *Transporter) Source(call goja.FunctionCall) goja.Value {
 	options := []pipeline.OptionFunc{
 		pipeline.WithClient(a.a),
 		pipeline.WithReader(a.a),
+		pipeline.WithCompactionInterval(t.config.CompactionInterval),
 	}
 	if t.config.LogDir != "" {
 		options = append(options, pipeline.WithCommitLog(

--- a/commitlog/commitlog.go
+++ b/commitlog/commitlog.go
@@ -299,9 +299,9 @@ func (c *CommitLog) replaceSegment(newSegment, oldSegment *Segment) error {
 	newSegment.rename(c.path, LogNameFormat)
 
 	// no need to keep a file handle open once compaction has completed
-	if err := newSegment.Close(); err != nil {
-		log.With("new_segment", newSegment.path).Errorf("failed to Close, %s", err)
-	}
+	// if err := newSegment.Close(); err != nil {
+	// 	log.With("new_segment", newSegment.path).Errorf("failed to Close, %s", err)
+	// }
 	log.With("new_segment", newSegment.path).
 		With("old_segment", oldSegment.path).
 		Infoln("segment replacement complete")

--- a/scripts/tests.sh
+++ b/scripts/tests.sh
@@ -21,7 +21,7 @@ elif [[ "$TRAVIS_EVENT_TYPE" != "cron" && "$TESTDIR" != integration_tests* ]]; t
   for t in "${test_dir[@]}"; do
     echo "testing $t"
     for d in $(go list ./$t); do
-        go test -v -coverprofile=profile.out -covermode=atomic $d -log.level=error
+        go test -v -coverprofile=profile.out -covermode=atomic $d
         if [ -f profile.out ]; then
             cat profile.out >> coverage.txt
             rm profile.out


### PR DESCRIPTION
integrates log compaction into the source node, required changes to how offsets get confirmed in order to be able to rebuild the offset map after compaction has occurred

fixes #370
