### PR TITLE
handle skipped messages due to ns or transforms better

### DIFF
--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -91,7 +91,7 @@ func (p *Pipe) Listen(fn func(message.Msg, offset.Offset) (message.Msg, error)) 
 		select {
 		case <-p.chStop:
 			if len(p.In) > 0 {
-				log.With("buffer_length", len(p.In)).Infoln("received stop, message buffer not empty, continuing...")
+				log.With("path", p.path).With("buffer_length", len(p.In)).Infoln("received stop, message buffer not empty, continuing...")
 				continue
 			}
 			log.Infoln("received stop, message buffer is empty, closing...")
@@ -133,7 +133,7 @@ func (p *Pipe) Stop() {
 		for {
 			select {
 			case <-timeout:
-				log.Errorln("timeout reached waiting for Out channels to clear")
+				log.With("path", p.path).Errorln("timeout reached waiting for Out channels to clear")
 				return
 			default:
 			}

--- a/pipeline/node_test.go
+++ b/pipeline/node_test.go
@@ -613,7 +613,7 @@ var (
 			func() (*Node, *StopWriter, func()) {
 				a := &StopWriter{}
 				n, _ := NewNodeWithOptions(
-					"starter", "stopWriter", defaultNsString,
+					"ns_filter_starter", "stopWriter", defaultNsString,
 					WithClient(a),
 					WithReader(a),
 					WithCommitLog([]commitlog.OptionFunc{
@@ -622,16 +622,15 @@ var (
 					}...),
 				)
 				NewNodeWithOptions(
-					"stopper", "stopWriter", "/blah/",
+					"ns_filter_stopper", "stopWriter", "/blah/",
 					WithClient(a),
 					WithWriter(a),
 					WithParent(n),
-					WithResumeTimeout(5*time.Second),
 					WithOffsetManager(&offset.MockManager{MemoryMap: map[string]uint64{}}),
 				)
 				return n, a, func() {}
 			},
-			0, 0, ErrResumeTimedOut,
+			0, 0, nil,
 		},
 		{
 			"with_offset_commit_error",


### PR DESCRIPTION
the original design for handling skipped messages was too naive in that it didn't account for multiple sinks each with its own namespace filter. this resulted in offsets never being committed which made it impossible to resume later.