### PR TITLE
refresh the session when the iter errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bugfixes
 - when using MongoDB as a source with tailing enabled and namespace filtering, it was possible for documents
 from others collections to be sent down the pipeline, fixed via [#386](https://github.com/compose/transporter/pull/386)
+- if transporter lost connection to MongoDB while tailing the oplog, the connection never successfully reconnected, fixed via [#398](https://github.com/compose/transporter/pull/398)
 
 ## v0.3.1 [2017-03-24]
 

--- a/adaptor/mongodb/reader.go
+++ b/adaptor/mongodb/reader.go
@@ -292,7 +292,7 @@ func (r *Reader) tailCollection(c string, mgoSession *mgo.Session, oplogTime bso
 			}
 			if iter.Err() != nil {
 				log.With("path", db).Errorf("error tailing oplog, %s", iter.Err())
-				// return adaptor.NewError(adaptor.CRITICAL, m.path, fmt.Sprintf("MongoDB error (error reading collection %s)", iter.Err()), nil)
+				mgoSession.Refresh()
 			}
 
 			query = bson.M{"ts": bson.M{"$gte": oplogTime}}


### PR DESCRIPTION
if the connection to mongodb fails while tailing, transporter was not attempting a reconnect and would endlessly fail

- [x] CHANGELOG.md updated

fixes #394 

