### PR TITLE
Capture flush errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.4.1 [UNRELEASED]
+
+### Bugfixes
+- when using an adaptor that was configured for flushing bulk messages based on an interval, it was possible for the bulk flush to error but not propagated back up to the pipeline, fixed via [#399](https://github.com/compose/transporter/pull/399)
+
 ## v0.4.0 [2017-08-15]
 
 ### Features

--- a/adaptor/elasticsearch/clients/v5/writer.go
+++ b/adaptor/elasticsearch/clients/v5/writer.go
@@ -29,6 +29,7 @@ type Writer struct {
 	sync.Mutex
 	confirmChan chan struct{}
 	logger      log.Logger
+	writeErr    error
 }
 
 func init() {
@@ -61,7 +62,7 @@ func init() {
 			FlushInterval(5 * time.Second). // commit every 5s
 			Before(w.preBulkProcessor).
 			After(w.postBulkProcessor).
-			Do(context.TODO())
+			Do(context.Background())
 		if err != nil {
 			return nil, err
 		}
@@ -72,6 +73,9 @@ func init() {
 
 func (w *Writer) Write(msg message.Msg) func(client.Session) (message.Msg, error) {
 	return func(s client.Session) (message.Msg, error) {
+		if w.writeErr != nil {
+			return msg, w.writeErr
+		}
 		w.Lock()
 		w.confirmChan = msg.Confirms()
 		w.Unlock()
@@ -125,4 +129,5 @@ func (w *Writer) postBulkProcessor(executionID int64, reqs []elastic.BulkableReq
 	if err != nil {
 		w.logger.With("executionID", executionID).Errorln(err)
 	}
+	w.writeErr = err
 }

--- a/adaptor/mongodb/bulk.go
+++ b/adaptor/mongodb/bulk.go
@@ -105,14 +105,19 @@ func (bOp *bulkOperation) calculateAvgObjSize(d data.Data) {
 }
 
 func (b *Bulk) run(done chan struct{}, wg *sync.WaitGroup) {
+	defer wg.Done()
 	for {
 		select {
 		case <-time.After(2 * time.Second):
-			b.flushAll()
+			if err := b.flushAll(); err != nil {
+				log.Errorf("flush error, %s", err)
+				return
+			}
 		case <-done:
 			log.Debugln("received done channel")
-			b.flushAll()
-			wg.Done()
+			if err := b.flushAll(); err != nil {
+				log.Errorf("flush error, %s", err)
+			}
 			return
 		}
 	}


### PR DESCRIPTION
while completing the integration tests migration from travisci to semaphoreci, it was discovered that bulk flushes occurring in the go routine were erroring and not bubbling up. the following change attempts to both log and stop transporter when a bulk flush error occurs outside of the `Write` func.

- [x] CHANGELOG.md updated

