### PR TITLE
Log sink pipe errors from write

### DIFF
--- a/pipeline/node.go
+++ b/pipeline/node.go
@@ -552,6 +552,9 @@ func (n *Node) write(msg message.Msg, off offset.Offset) (message.Msg, error) {
 	c := make(chan writeResult)
 	go func() {
 		m, err := client.Write(n.c, n.writer, msg)
+		if err != nil {
+			n.l.Errorf("write error, %s", err)
+		}
 		c <- writeResult{m, err}
 	}()
 	select {

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -125,27 +125,28 @@ var (
 			},
 			client.ErrMockConnect,
 		},
-		// uncomment this once the error handling mess is sorted out
-		// {
-		// 	func() *Node {
-		// 		a := &adaptor.Mock{}
-		// 		n, _ := NewNodeWithOptions(
-		// 			"starter", "stopWriter", defaultNsString,
-		// 			WithClient(a),
-		// 			WithReader(a),
-		// 			WithCommitLog("testdata/restart_from_end", 1024),
-		// 		)
-		// 		NewNodeWithOptions(
-		// 			"stopperWriteErr", "stopWriter", defaultNsString,
-		// 			WithClient(a),
-		// 			WithWriter(&adaptor.MockWriterErr{}),
-		// 			WithParent(n),
-		// 			WithOffsetManager(&offset.MockManager{MemoryMap: map[string]uint64{}}),
-		// 		)
-		// 		return n
-		// 	},
-		// 	client.ErrMockWrite,
-		// },
+		{
+			func() *Node {
+				a := &adaptor.Mock{}
+				n, _ := NewNodeWithOptions(
+					"starter", "stopWriter", defaultNsString,
+					WithClient(a),
+					WithReader(a),
+					WithCommitLog([]commitlog.OptionFunc{
+						commitlog.WithPath("testdata/pipeline_run"),
+					}...),
+				)
+				NewNodeWithOptions(
+					"stopperWriteErr", "stopWriter", defaultNsString,
+					WithClient(a),
+					WithWriter(&adaptor.MockWriterErr{}),
+					WithParent(n),
+					WithOffsetManager(&offset.MockManager{MemoryMap: map[string]uint64{}}),
+				)
+				return n
+			},
+			client.ErrMockWrite,
+		},
 	}
 )
 


### PR DESCRIPTION
Also add back a commented-out write error test for pipeline

Connects to #426

This feels like the lowest logical spot to put this. I had spent some time looking into the chain of channels and listeners, thinking it might be better to push it even further down, e.g. in pipeline, but at that point it started to get too tangled up in control flow imo.

### Required for all PRs:

- [ ] CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)
- [ ] README.md updated (if needed)
