### PR TITLE
reduce max mongo bulk ops to 1000

### DIFF
--- a/adaptor/mongodb/bulk.go
+++ b/adaptor/mongodb/bulk.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	maxObjSize     int = 10000
+	maxObjSize     int = 1000
 	maxBSONObjSize int = 4800000
 )
 


### PR DESCRIPTION
Prior to Mongo 3.5, the max bulk op size is 1000. In latest versions, it looks like it is configurable by the server. Future work could be to detect version and configured max bulk op size and set appropriately. (mgo should really be doing this...)

Commit which shows bulk op size: https://github.com/mongodb/mongo/commit/50328747a0f66362e95652822bb37ccf1fff67ad