### PR TITLE
postgres/tailer: data change row detection fixed

### DIFF
--- a/adaptor/postgres/adaptor_test.go
+++ b/adaptor/postgres/adaptor_test.go
@@ -80,7 +80,8 @@ var (
 	}
 
 	randomHeros = []string{"Superwoman", "Wonder Woman", "Batman", "Superman",
-		"Thor", "Iron Man", "Spiderman", "Hulk", "Star-Lord", "Black Widow"}
+		"Thor", "Iron Man", "Spiderman", "Hulk", "Star-Lord", "Black Widow",
+		"Ant\nMan"}
 )
 
 type TestData struct {

--- a/adaptor/postgres/tailer.go
+++ b/adaptor/postgres/tailer.go
@@ -47,7 +47,6 @@ func (t *Tailer) Read(resumeMap map[string]client.MessageSet, filterFn client.Ns
 			for msg := range msgChan {
 				out <- msg
 			}
-
 			// start tailing
 			log.With("db", session.db).With("logical_decoding_slot", t.replicationSlot).Infoln("Listening for changes...")
 			for {
@@ -75,7 +74,7 @@ func (t *Tailer) Read(resumeMap map[string]client.MessageSet, filterFn client.Ns
 // Use Postgres logical decoding to retrieve the latest changes
 func (t *Tailer) pluckFromLogicalDecoding(s *Session, filterFn client.NsFilterFunc) ([]client.MessageSet, error) {
 	var result []client.MessageSet
-	dataMatcher := regexp.MustCompile("^table ([^\\.]+).([^\\.]+): (INSERT|DELETE|UPDATE): (.+)$") // 1 - schema, 2 - table, 3 - action, 4 - remaining
+	dataMatcher := regexp.MustCompile("(?s)^table ([^\\.]+)\\.([^:]+): (INSERT|DELETE|UPDATE): (.+)$") // 1 - schema, 2 - table, 3 - action, 4 - remaining
 
 	changesResult, err := s.pqSession.Query(fmt.Sprintf("SELECT * FROM pg_logical_slot_get_changes('%v', NULL, NULL);", t.replicationSlot))
 	if err != nil {


### PR DESCRIPTION
When you have newlines in database fields, the postgres tailer will not work.
This is due to the regular expression that is used to detect change rows in the data from the used
replication slot . 

The regular expression uses the dot-directive which does not consume newlines by default. This issues the newline problem. With this slightly modified regular expression, the problem can be solved.

