### PR TITLE
Fix CI: Postgresql install was missing apt-get update

### DIFF
--- a/config/postgres/Dockerfile
+++ b/config/postgres/Dockerfile
@@ -5,10 +5,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
     apt install -y wget netcat lsb-release gnupg2
 
-
+# Debug lsb_release name:
+# RUN lsb_release -cs
 RUN echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt install -y postgresql-$VERSION
+    apt-get update && apt install -y postgresql-$VERSION
 
 COPY scripts/ /tmp/postgresql/scripts/
 COPY ph_hba.conf /etc/postgresql/$VERSION/main/pg_hba.conf


### PR DESCRIPTION
Github actions recently switched from focal to jammy and for some reason
this caused the Postgresql install to fail. According to [the wiki][1] Jammy
is supported, but the install script was missing an `apt-get update`.
Adding that seems to fix things.
    
Leaving a commented out `lsb_release` for debugging.

[1]: https://wiki.postgresql.org/wiki/Apt

### Required for all PRs:

- N/A ~CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)~
- N/A ~README.md updated (if needed)~
