### PR TITLE
Adaptor: add certificate support for elastic

### DIFF
--- a/adaptor/elasticsearch/README.md
+++ b/adaptor/elasticsearch/README.md
@@ -40,6 +40,7 @@ es = elasticsearch({
   "aws_access_key": "XXX" // optional, used for signing requests to AWS Elasticsearch service
   "aws_access_secret": "XXX" // optional, used for signing requests to AWS Elasticsearch service
   "parent_id": "elastic_parent" // optional, used for specifying parent-child relationships
+  "certificate": "ca.crt" // optional, useful when xpack security is enabled
 })
 ```
 
@@ -101,6 +102,7 @@ es = elasticsearch({
   "aws_access_key": "XXX"
   "aws_access_secret": "XXX"
   "parent_id": "company_id"
+  "certificate": "ca.crt"
 })
 ```
 

--- a/adaptor/elasticsearch/transport.go
+++ b/adaptor/elasticsearch/transport.go
@@ -12,18 +12,18 @@ type AWSTransport struct {
 	transport   http.RoundTripper
 }
 
-func newTransport(accessKeyID, secretAccessKey string) http.RoundTripper {
-	t := http.DefaultTransport
+func newTransport(accessKeyID, secretAccessKey string, httpTransport http.RoundTripper) http.RoundTripper {
+	// t := http.DefaultTransport
 	if accessKeyID != "" && secretAccessKey != "" {
 		return &AWSTransport{
 			Credentials: awsauth.Credentials{
 				AccessKeyID:     accessKeyID,
 				SecretAccessKey: secretAccessKey,
 			},
-			transport: t,
+			transport: httpTransport,
 		}
 	}
-	return t
+	return httpTransport
 }
 
 // RoundTrip implementation

--- a/adaptor/elasticsearch/transport_test.go
+++ b/adaptor/elasticsearch/transport_test.go
@@ -35,11 +35,11 @@ var transportTests = []struct {
 }{
 	{
 		"/aws",
-		&http.Client{Transport: newTransport(awsAccessKey, awsSecretKey)},
+		&http.Client{Transport: newTransport(awsAccessKey, awsSecretKey, http.DefaultTransport)},
 	},
 	{
 		"/other",
-		&http.Client{Transport: newTransport("", "")},
+		&http.Client{Transport: newTransport("", "", http.DefaultTransport)},
 	},
 }
 

--- a/client/error.go
+++ b/client/error.go
@@ -24,6 +24,14 @@ func (e InvalidTimeoutError) Error() string {
 	return fmt.Sprintf("Invalid Timeout, %s", e.Timeout)
 }
 
+type InvalidCertificateError struct {
+	Err string
+}
+
+func (e InvalidCertificateError) Error() string {
+	return fmt.Sprintf("Invalid Certificate, %s", e.Err)
+}
+
 // ErrInvalidCert represents the error returned when a specified certificate was not valid
 var ErrInvalidCert = errors.New("invalid cert error")
 


### PR DESCRIPTION
When XPack security is enabled a certificate is required to communicate with the API.

### Required for all PRs:

- [ ] CHANGELOG.md updated (feel free to wait until changes have been reviewed by a maintainer)
- [ ] README.md updated (if needed)
